### PR TITLE
Don’t write events inside a transaction

### DIFF
--- a/lib/event_sourcery/event_sink_adapters/postgres.rb
+++ b/lib/event_sourcery/event_sink_adapters/postgres.rb
@@ -7,16 +7,14 @@ module EventSourcery
       end
 
       def sink(aggregate_id:, type:, body:)
-        connection.transaction do
-          result = events_table.
-            returning(:id).
-            insert(aggregate_id: aggregate_id,
-                   type: type.to_s,
-                   body: ::Sequel.pg_json(body))
-          event_id = result.first.fetch(:id)
-          connection.notify('new_event', payload: event_id)
-          true
-        end
+        result = events_table.
+          returning(:id).
+          insert(aggregate_id: aggregate_id,
+                 type: type.to_s,
+                 body: ::Sequel.pg_json(body))
+        event_id = result.first.fetch(:id)
+        connection.notify('new_event', payload: event_id)
+        true
       end
 
       private


### PR DESCRIPTION
This is probably the main cause of the out of sequence errors we’ve seen, and it’s definitely not required for data integrity.

Addresses: https://github.com/envato/event_sourcery/pull/6
