### PR TITLE
Allow getting latest event ID by event type

### DIFF
--- a/lib/event_sourcery/event_source_adapters/postgres.rb
+++ b/lib/event_sourcery/event_source_adapters/postgres.rb
@@ -20,8 +20,12 @@ module EventSourcery
         end
       end
 
-      def latest_event_id
-        latest_event = events_table.order(:id).last
+      def latest_event_id(event_types: nil)
+        latest_event = events_table
+        if event_types
+          latest_event = latest_event.where(type: event_types)
+        end
+        latest_event = latest_event.order(:id).last
         if latest_event
           latest_event[:id]
         else

--- a/spec/event_sourcery/event_source_adapters/postgres_spec.rb
+++ b/spec/event_sourcery/event_source_adapters/postgres_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe EventSourcery::EventSourceAdapters::Postgres do
         expect(adapter.latest_event_id).to eq 0
       end
     end
+
+    context 'with event type filtering' do
+      it 'gets the latest event ID for a set of event types' do
+        add_event(aggregate_id: aggregate_id, type: 'type_1')
+        add_event(aggregate_id: aggregate_id, type: 'type_1')
+        add_event(aggregate_id: aggregate_id, type: 'type_2')
+
+        expect(adapter.latest_event_id(event_types: ['type_1'])).to eq 2
+        expect(adapter.latest_event_id(event_types: ['type_2'])).to eq 3
+        expect(adapter.latest_event_id(event_types: ['type_1', 'type_2'])).to eq 3
+      end
+    end
   end
 
   describe '#get_events_for_aggregate_id' do


### PR DESCRIPTION
In order to be able to support tracking lag metrics correctly when event handlers don't see all events (only the ones they care about).
