### PR TITLE
Remove code related to the DEP's clutch

### DIFF
--- a/lib/event_sourcery/event_processing/downstream_event_processor.rb
+++ b/lib/event_sourcery/event_processing/downstream_event_processor.rb
@@ -55,14 +55,8 @@ module EventSourcery
       module ProcessHandler
         def process(event)
           @event = event
-          if self.class.emits_events? && clutch_down?
-            keep_track_of_previously_emitted_events
-          end
           if self.class.processes?(event.type)
             super(event)
-          end
-          if clutch_down? && event_is_latest_event_on_setup?
-            release_clutch
           end
           tracker.processed_event(self.class.processor_name, event.id)
           @event = nil
@@ -77,46 +71,16 @@ module EventSourcery
 
       attr_reader :event_sink, :event_source, :event, :latest_event_id_on_setup
 
-      def clutch_down?
-        false
-      end
-
-      def release_clutch
-        return if events_to_emit.empty?
-        begin
-          event_id, (event_args, action) = events_to_emit.shift
-          invoke_action_and_emit_event(event_args.fetch(:aggregate_id), event_args.fetch(:type), event_args.fetch(:body), action)
-        end while events_to_emit.length != 0
-      end
-
       def emit_event(aggregate_id:, type:, body: {}, &block)
         raise UndeclaredEventEmissionError unless self.class.emits_event?(type)
         body = body.merge(DRIVEN_BY_EVENT_PAYLOAD_KEY => event.id)
-        if clutch_down?
-          events_to_emit[event.id] = [{ aggregate_id: aggregate_id, type: type, body: body }, block]
-        else
-          invoke_action_and_emit_event(aggregate_id, type, body, block)
-        end
+        invoke_action_and_emit_event(aggregate_id, type, body, block)
       end
 
       def invoke_action_and_emit_event(aggregate_id, type, body, action)
         action.call(body) if action
         # TODO: emit_event should probably take an event object rather than these params
         event_sink.sink(Event.new(aggregate_id: aggregate_id, type: type, body: body))
-      end
-
-      def keep_track_of_previously_emitted_events
-        if self.class.emit_events.include?(event.type)
-          events_to_emit.delete(event.body[DRIVEN_BY_EVENT_PAYLOAD_KEY])
-        end
-      end
-
-      def events_to_emit
-        @events_to_emit ||= {}
-      end
-
-      def event_is_latest_event_on_setup?
-        latest_event_id_on_setup == event.id
       end
     end
   end

--- a/spec/event_sourcery/event_processing/downstream_event_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/downstream_event_processor_spec.rb
@@ -211,34 +211,6 @@ RSpec.describe EventSourcery::EventProcessing::DownstreamEventProcessor do
         event_source.get_next_from(0, limit: 100)[-n..-1]
       end
 
-      xit "doesn't action if the event is not newer than or the latest event captured in setup" do
-        dep.process(event_1)
-        expect(TestActioner.actioned).to eq []
-        dep.process(event_2)
-        expect(TestActioner.actioned).to eq []
-        dep.process(event_3)
-        expect(TestActioner.actioned).to eq []
-        dep.process(event_4)
-        expect(TestActioner.actioned).to eq [3, 4]
-        dep.process(event_5)
-        expect(TestActioner.actioned).to eq [3, 4, 5]
-      end
-
-      xit "emits events when it reaches the end of the stream as captured in setup" do
-        dep.process(event_1)
-        expect(event_count).to eq 4
-        dep.process(event_2)
-        expect(event_count).to eq 4
-        dep.process(event_3)
-        expect(event_count).to eq 4
-        dep.process(event_4)
-        expect(event_count).to eq 6
-        expect(latest_events(2).map(&:type)).to eq ['echo_event', 'echo_event']
-        expect(latest_events(2).map(&:body).map{|b| b[EventSourcery::EventProcessing::DownstreamEventProcessor::DRIVEN_BY_EVENT_PAYLOAD_KEY]}).to eq [3, 4]
-        dep.process(event_5)
-        expect(event_count).to eq 7
-      end
-
       it 'releases the clutch after it has processes the latest event captured in setup, not before' do
         [event_1, event_2, event_3, event_4, event_5, event_6].each do |event|
           dep.process(event)


### PR DESCRIPTION
It's making this look really complicated, and it's technically disabled anyways. Let's fix the issues we had with this approach separately. Still keeping the driven by event ID because that's really useful anyway.
