### PR TITLE
Make process_events API private, add subscribe_to(event_store)

### DIFF
--- a/lib/event_sourcery/event_processing/downstream_event_processor.rb
+++ b/lib/event_sourcery/event_processing/downstream_event_processor.rb
@@ -8,6 +8,7 @@ module EventSourcery
         base.extend(ClassMethods)
         base.prepend(TableOwner)
         base.prepend(ProcessHandler)
+        base.include(InstanceMethods)
       end
 
       module ClassMethods
@@ -28,14 +29,16 @@ module EventSourcery
         end
       end
 
-      def initialize(tracker:, db_connection: nil, event_source: nil, event_sink: nil)
-        @tracker = tracker
-        @event_source = event_source
-        @event_sink = event_sink
-        @db_connection = db_connection
-        if self.class.emits_events?
-          if event_sink.nil? || event_source.nil?
-            raise ArgumentError, 'An event sink and source is required for processors that emit events'
+      module InstanceMethods
+        def initialize(tracker:, db_connection: nil, event_source: nil, event_sink: nil)
+          @tracker = tracker
+          @event_source = event_source
+          @event_sink = event_sink
+          @db_connection = db_connection
+          if self.class.emits_events?
+            if event_sink.nil? || event_source.nil?
+              raise ArgumentError, 'An event sink and source is required for processors that emit events'
+            end
           end
         end
       end

--- a/lib/event_sourcery/event_processing/event_processor.rb
+++ b/lib/event_sourcery/event_processing/event_processor.rb
@@ -3,6 +3,13 @@ module EventSourcery
     module EventProcessor
       def self.included(base)
         base.extend(ClassMethods)
+        base.include(InstanceMethods)
+      end
+
+      module InstanceMethods
+        def initialize(tracker:)
+          @tracker = tracker
+        end
       end
 
       module ClassMethods

--- a/lib/event_sourcery/event_processing/projector.rb
+++ b/lib/event_sourcery/event_processing/projector.rb
@@ -5,11 +5,14 @@ module EventSourcery
         base.include(EventProcessor)
         base.prepend(TableOwner)
         base.prepend(ProcessHandler)
+        base.include(InstanceMethods)
       end
 
-      def initialize(tracker:, db_connection:)
-        @tracker = tracker
-        @db_connection = db_connection
+      module InstanceMethods
+        def initialize(tracker:, db_connection:)
+          @tracker = tracker
+          @db_connection = db_connection
+        end
       end
 
       module ProcessHandler

--- a/spec/event_sourcery/event_processing/event_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/event_processor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EventSourcery::EventProcessing::EventProcessor do
         @events ||= []
         @events << event
       end
-    end.new.tap { |p| p.tracker = tracker }
+    end.new(tracker: tracker)
   end
 
   describe '#processor_name' do


### PR DESCRIPTION
``` ruby
event_processor = MyEventProcessor.new(tracker: tracker)
event_processor.subscribe_to(event_store) # blocking
```
