### PR TITLE
Expose the type of event that couldn't be processed

### DIFF
--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -30,7 +30,8 @@ module EventSourcery
             elsif defined?(super)
               super(event)
             else
-              raise UnableToProcessEventError
+              raise UnableToProcessEventError, "I don't know how to process '#{event.type}' events. "\
+                                               "To process this event implement a method named '#{handler_method_name}'"
             end
           end
           @_event = nil

--- a/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
           it 'is used to process the event' do
             expect {
               event_processor.process(event)
-            }.to raise_error(EventSourcery::UnableToProcessEventError)
+            }.to raise_error(EventSourcery::UnableToProcessEventError, /I don't know how to process 'item_added' events/)
           end
         end
       end


### PR DESCRIPTION
We raise an error when a processor receives an event for which it has no handling method defined. To help diagnose problems in development let's expose the type of event that couldn't be processed.

As a nicety, also specify the name of the method to implement to be able to process the event in question.
