### PR TITLE
Remove not null constraint from version column on events (created by schema)

### DIFF
--- a/lib/event_sourcery/event_store/postgres/schema.rb
+++ b/lib/event_sourcery/event_store/postgres/schema.rb
@@ -16,7 +16,7 @@ module EventSourcery
             column :aggregate_id, 'uuid not null'
             column :type, 'varchar(255) not null'
             column :body, 'json not null'
-            column :version, 'bigint not null'
+            column :version, 'bigint'
             column :created_at, 'timestamp without time zone not null default (now() at time zone \'utc\')'
             index [:aggregate_id, :version], unique: true
             index :type


### PR DESCRIPTION
I've been playing around with a test implementation of Event Sourcery. I used the postgres schema module to create the event store tables. I then discovered that the `version` column having a `not null` constraint causes problems when inserting events via `EventStore::Postgres::Connection` which does not use the version column and violates the constraint.

Do we think it is reasonable to remove this constraint and instead expect the `EventStore::Postgres::ConnectionWithOptimisticConcurrency` connection to ensure a version is set so either connection can work?
