### PR TITLE
Configure appropriate event store when configuring an event store database

### DIFF
--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -2,10 +2,7 @@ require 'logger'
 
 module EventSourcery
   class Config
-    attr_accessor :event_sink,
-                  :event_source,
-                  :event_store,
-                  :projections_database,
+    attr_accessor :projections_database,
                   :event_store_database,
                   :event_tracker,
                   :on_unknown_event,
@@ -15,7 +12,10 @@ module EventSourcery
                   :events_table_name,
                   :callback_interval_if_no_new_events
 
-    attr_writer :logger
+    attr_writer :event_store,
+                :event_source,
+                :event_sink,
+                :logger
 
     def initialize
       @on_unknown_event = proc { |event|
@@ -28,16 +28,24 @@ module EventSourcery
       @callback_interval_if_no_new_events = 10
     end
 
-    def use_optimistic_concurrency=(value)
-      @use_optimistic_concurrency = value
-      set_database_event_store(@event_store_database) if @event_store_database
+    def event_store
+      if @event_store_database
+        if use_optimistic_concurrency
+          EventStore::Postgres::ConnectionWithOptimisticConcurrency.new(@event_store_database)
+        else
+          EventStore::Postgres::Connection.new(@event_store_database)
+        end
+      else
+        @event_store
+      end
     end
 
-    def event_store_database=(sequel_connection)
-      @event_store_database = sequel_connection
-      set_database_event_store(sequel_connection)
-      @event_sink = EventStore::EventSink.new(@event_store)
-      @event_source = EventStore::EventSource.new(@event_store)
+    def event_source
+      EventStore::EventSource.new(event_store)
+    end
+
+    def event_sink
+      EventStore::EventSink.new(event_store)
     end
 
     def projections_database=(sequel_connection)
@@ -48,16 +56,6 @@ module EventSourcery
     def logger
       @logger ||= ::Logger.new(STDOUT).tap do |logger|
         logger.level = Logger::DEBUG
-      end
-    end
-
-    private
-
-    def set_database_event_store(sequel_connection)
-      @event_store = if use_optimistic_concurrency
-        EventStore::Postgres::ConnectionWithOptimisticConcurrency.new(sequel_connection)
-      else
-        EventStore::Postgres::Connection.new(sequel_connection)
       end
     end
   end

--- a/spec/event_sourcery/config_spec.rb
+++ b/spec/event_sourcery/config_spec.rb
@@ -3,60 +3,43 @@ RSpec.describe EventSourcery::Config do
 
   let(:use_optimistic_concurrency) { false }
 
-  context 'when use_optimistic_concurrency is configured' do
-    let(:use_optimistic_concurrency) { false }
-
-    it 'sets the use_optimistic_concurrency flag' do
-      config.use_optimistic_concurrency = use_optimistic_concurrency
-      expect(config.use_optimistic_concurrency).to eq(false)
-    end
-
-    context 'and an event store database has previously been configured' do
-      let(:connection) { double }
-      let(:use_optimistic_concurrency) { true }
+  context 'when reading the event_store' do
+    context 'and an event_store_database is set' do
       before do
-        allow(EventSourcery::EventStore::Postgres::ConnectionWithOptimisticConcurrency).to receive(:new)
-          .with(pg_connection).and_return(connection)
-        config.event_store_database = pg_connection
+        config.event_store_database = double
       end
 
-      it 'sets the event store based on the use_optimistic_concurrency value' do
-        config.use_optimistic_concurrency = use_optimistic_concurrency
-        expect(config.event_store).to eq(connection)
+      context 'and using optimistic concurrency' do
+        before do
+          config.use_optimistic_concurrency = true
+        end
+
+        it 'returns a EventSourcery::EventStore::Postgres::ConnectionWithOptimisticConcurrency' do
+          expect(config.event_store).to be_instance_of(EventSourcery::EventStore::Postgres::ConnectionWithOptimisticConcurrency)
+        end
       end
-    end
-  end
 
-  context 'when the event store database is configured' do
-    before do
-      config.use_optimistic_concurrency = use_optimistic_concurrency
-      config.event_store_database = pg_connection
-    end
+      context 'and not using optimistic concurrency' do
+        before do
+          config.use_optimistic_concurrency = false
+        end
 
-    context 'and using optimistic concurrency' do
-      let(:use_optimistic_concurrency) { true }
-
-      it 'sets the event store as a Postgres::ConnectionWithOptimisticConcurrency' do
-        expect(config.event_store).to be_instance_of(
-          EventSourcery::EventStore::Postgres::ConnectionWithOptimisticConcurrency
-        )
+        it 'returns a EventSourcery::EventStore::Postgres::Connection' do
+          expect(config.event_store).to be_instance_of(EventSourcery::EventStore::Postgres::Connection)
+        end
       end
     end
 
-    context 'and not using optimistic concurrency' do
-      let(:use_optimistic_concurrency) { false }
-
-      it 'sets the event store as a Postgres::Connection' do
-        expect(config.event_store).to be_instance_of(EventSourcery::EventStore::Postgres::Connection)
+    context 'and an event_store is set' do
+      let(:event_store) { double(:event_store) }
+      before do
+        config.event_store = event_store
+        config.event_store_database = nil
       end
-    end
 
-    it 'sets the event sink' do
-      expect(config.event_sink).to be_instance_of(EventSourcery::EventStore::EventSink)
-    end
-
-    it 'sets the event source' do
-      expect(config.event_source).to be_instance_of(EventSourcery::EventStore::EventSource)
+      it 'returns the event_store' do
+        expect(config.event_store).to eq(event_store)
+      end
     end
   end
 


### PR DESCRIPTION
Configuring event_store_database will set the correct event_store postgres connection based on the `use_optimistic_concurrency` value

Also added an override for the `use_optimistic_concurrency` writer that will set the correct event_store if an event_store_database was previously set (so order of setting the configuration options do not matter)
