### PR TITLE
Ignore expected_version param in memory store

### DIFF
--- a/lib/event_sourcery/event_store/memory.rb
+++ b/lib/event_sourcery/event_store/memory.rb
@@ -7,7 +7,7 @@ module EventSourcery
         @events = events
       end
 
-      def sink(event_or_events)
+      def sink(event_or_events, expected_version: nil)
         events = Array(event_or_events)
         events.each do |event|
           id = @events.size + 1

--- a/spec/event_sourcery/event_store/memory_spec.rb
+++ b/spec/event_sourcery/event_store/memory_spec.rb
@@ -3,4 +3,10 @@ RSpec.describe EventSourcery::EventStore::Memory do
   subject(:event_store) { described_class.new }
 
   include_examples 'an event store'
+
+  it 'ignores an expected_version param' do
+    expect {
+      event_store.sink(EventSourcery::Event.new(type: 'blah', aggregate_id: SecureRandom.uuid, body: {}))
+    }.to_not raise_error
+  end
 end


### PR DESCRIPTION
This store is just used for testing and not intended for concurrent saving of events so let's add this param to be compatible with the optimistic locking store and just ignore it.
