### PR TITLE
trap SIGINT and have forked subprocesses exit gracefully

### DIFF
--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -12,6 +12,7 @@ module EventSourcery
         EventSourcery.logger.info { "Forking ESP processes" }
         @event_processors.each do |event_processor|
           fork do
+            Signal.trap("SIGINT") { exit }
             start_processor(event_processor)
           end
         end

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
       allow(esp).to receive(:subscribe_to)
     end
 
+    it 'forks and traps SIGINT signal inside subprocess' do
+      expect(esp_runner).to receive(:fork) do |&block|
+        expect(Signal).to receive(:trap).with('SIGINT')
+        block.call
+      end
+      esp_runner.start!
+    end
+
     it 'subscribes ESPs' do
       esp_runner.start!
       expect(esp).to have_received(:subscribe_to).with(event_store)


### PR DESCRIPTION
I was finding that when you CRTL+C foreman that it was leaving zombie processes lying around.
This seems to do the trick. If there is a better way that anyone knows, please let me know. 

Foreman tries issuing a SIGINT before a SIGTERM. The SIGTERM didn't appear to be making its way down to the forked child processes. 
