### PR TITLE
AggregateRoot#apply_event accepts hash

### DIFF
--- a/lib/event_sourcery/command/aggregate_root.rb
+++ b/lib/event_sourcery/command/aggregate_root.rb
@@ -22,7 +22,8 @@ module EventSourcery
 
       attr_reader :id, :event_sink
 
-      def apply_event(event)
+      def apply_event(event_or_hash)
+        event = to_event(event_or_hash)
         mutate_state_from(event)
         unless event.persisted?
           event_with_aggregate_id = Event.new(aggregate_id: @id,
@@ -34,6 +35,14 @@ module EventSourcery
           else
             event_sink.sink(event_with_aggregate_id)
           end
+        end
+      end
+
+      def to_event(event_or_hash)
+        if event_or_hash.is_a?(Event)
+          event_or_hash
+        else
+          Event.new(event_or_hash)
         end
       end
 


### PR DESCRIPTION
In a way consistent with [`Reactor#emit_event`](https://github.com/envato/event_sourcery/blob/master/lib/event_sourcery/event_processing/reactor.rb#L51-L56), wouldn't it be great if `apply_event` could accept a hash of event attributes? Then our aggregate mutators would be even simpler:

``` ruby
    class Soul
      include EventSourcery::Command::AggregateRoot

      def sell(payload)
        apply_event(type: :soul_sold, body: payload)
      end

      private

      def apply_soul_sold(_)
      end
    end

```

Compared to the current requirements where the aggregate must instantiate an `Event`:

``` ruby
      def sell(payload)
        apply_event(
          EventSourcery::Event.new(type: :soul_sold, body: payload)
        )
      end
```
