### PR TITLE
Use configured database by default in schema creation

### DIFF
--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -41,6 +41,6 @@ RSpec.configure do |config|
   config.before do
     pg_connection.execute("drop table if exists events")
     pg_connection.execute("drop table if exists aggregates")
-    EventSourcery::EventStore::Postgres::Schema.create(pg_connection)
+    EventSourcery::EventStore::Postgres::Schema.create(db: pg_connection)
   end
 end


### PR DESCRIPTION
This change makes it so that passing in a database becomes optional when creating database tables. EventSourcery will now automatically use EventSourcery.config.event_store if no database is passed in as an argument. We have the database, so why not use it? 😄 

This also makes a _slight_ change to the schema creation API, by making the database a kwarg.

cc @stevehodgkiss 
