### PR TITLE
Add a default command initializer

### DIFF
--- a/lib/event_sourcery/command.rb
+++ b/lib/event_sourcery/command.rb
@@ -12,6 +12,13 @@ module EventSourcery
       end
     end
 
+    attr_reader :aggregate_id, :payload
+
+    def initialize(aggregate_id:, payload:)
+      @aggregate_id = aggregate_id
+      @payload = payload
+    end
+
     def validate!
       raise NotImplementedError
     end


### PR DESCRIPTION
Commands are likely to be built in a similar fashion--with an aggregate ID and a payload--and therefore it makes sense to not duplicate this logic across commands in our application.
