### PR TITLE
Add RejectedCommandError to AggregateRoot

### DIFF
--- a/lib/event_sourcery/command/aggregate_root.rb
+++ b/lib/event_sourcery/command/aggregate_root.rb
@@ -2,6 +2,7 @@ module EventSourcery
   module Command
     module AggregateRoot
       UnknownEventError = Class.new(RuntimeError)
+      RejectedCommandError = Class.new(RuntimeError)
 
       def initialize(id, event_sink, on_unknown_event: EventSourcery.config.on_unknown_event, use_optimistic_concurrency: EventSourcery.config.use_optimistic_concurrency)
         @id = id


### PR DESCRIPTION
This is an error many aggregates are going to make use of, therefore it makes sense to put it in the AggregateRoot so we don't have to redefine it across aggregates.
