### PR TITLE
PoC for new stuct-like command module

### DIFF
--- a/lib/event_sourcery/command.rb
+++ b/lib/event_sourcery/command.rb
@@ -1,3 +1,5 @@
+require 'virtus'
+
 module EventSourcery
   module Command
     def self.included(base)
@@ -10,10 +12,34 @@ module EventSourcery
           command.validate!
         end
       end
+
+      def attributes
+        @@attributes ||= {}
+      end
+
+      def attribute(name, type, options={})
+        if [ :aggregate_id, :payload ].include?(name.to_sym)
+          raise ReservedAttributeName, "'#{name}' is a reserved attribute name"
+        end
+
+        attr_reader name
+
+        virtus_options = { strict: true }
+        virtus_options[:required] = false if options[:optional]
+
+        self.attributes[name] = ::Virtus::Attribute.build(type, virtus_options)
+      end
+    end
+
+    def initialize(aggregate_id:, payload:)
+      @aggregate_id = aggregate_id
+      @payload = payload
     end
 
     def validate!
-      raise NotImplementedError
+      self.class.attributes.each do |attribute_name, coercer|
+        instance_variable_set("@#{attribute_name}", coercer.coerce(@payload[attribute_name]))
+      end
     end
   end
 end


### PR DESCRIPTION
**Note: This is a PoC for feedback**

This introduces new functionality to the `Command` module. The idea is to make commands a "strongly typed struct," a value object that refuses to initialize if you give it the wrong parameters. With this change, you can specify what attributes a command should have and it will automatically coerce/validate the data given on initialization.

This aims to replace the `RequestObject` pattern that has been used in a few different systems. I think for the majority of cases, the RequestObject is doing the job of the command and is only adding unnecessary complexity.

In the below implementation, it's currently only possible to specify the attribute's type and whether it's optional (or not). If this approach is something we want to continue, I imagine we would extend it to include defaults and more specific validations as well. This is a proof of concept, not a fully-fledged feature.

The `Command` module relies on Virtus to make this happen. I picked Virtus because it's already required by EventSourcery.

The DSL this introduces looks like this:

```ruby
module Calendar
  module Appointment
    module Schedule
      class Command
        include EventSourcery::Command

        attribute :title, String
        attribute :start_time, DateTime
        attribute :duration, Integer
        attribute :location, String, optional: true
      end
    end
  end
end

payload = {
  title: 'All hands',
  start_time: '2016-10-30T06:28:33+00:00',
  duration: '60',
  location: 'Nashville Auditorium',
}

cmd = Calendar::Appointment::Schedule::Command.build!(aggregate_id: uuid, payload: payload)
cmd.title # => 'All hands'
cmd.start_time # => #<DateTime: 2016-10-30T06:28:33+00:00 ((2457692j,23313s,0n),+0s,2299161j)>
cmd.duration # => 60
cmd.location # => "Nashville Auditorium"

payload.delete(:location)
Calendar::Appointment::Schedule::Command.build!(aggregate_id: uuid, payload: payload)

payload.delete(:duration)
Calendar::Appointment::Schedule::Command.build!(aggregate_id: uuid, payload: payload)
# => Virtus::CoercionError(Failed to coerce nil into Integer)

payload[:duration] = 'just a string'
Calendar::Appointment::Schedule::Command.build!(aggregate_id: uuid, payload: payload)
# => Virtus::CoercionError(Failed to coerce "just a string" into Integer)
```