### PR TITLE
Pass the aggregate to the on_unknown_event block

### DIFF
--- a/lib/event_sourcery/command/aggregate_root.rb
+++ b/lib/event_sourcery/command/aggregate_root.rb
@@ -53,7 +53,7 @@ module EventSourcery
         if respond_to?(method_name, true)
           send(method_name, event)
         else
-          @on_unknown_event.call(event)
+          @on_unknown_event.call(event, self)
         end
       end
     end

--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -19,8 +19,8 @@ module EventSourcery
                 :logger
 
     def initialize
-      @on_unknown_event = proc { |event|
-        raise Command::AggregateRoot::UnknownEventError.new("#{event.type} is unknown to #{self.class.name}")
+      @on_unknown_event = proc { |event, aggregate|
+        raise Command::AggregateRoot::UnknownEventError, "#{event.type} is unknown to #{aggregate.class.name}"
       }
       @use_optimistic_concurrency = true
       @lock_table_to_guarantee_linear_sequence_id_growth = true


### PR DESCRIPTION
So we know which aggregate class is missing the apply method.
Previously, the default block would report the Config class.

> item_removed is unknown to EventSourcery::Config