### PR TITLE
Add methods for emitting permitted events to Reactor module

### DIFF
--- a/lib/event_sourcery/event_processing/reactor.rb
+++ b/lib/event_sourcery/event_processing/reactor.rb
@@ -15,7 +15,7 @@ module EventSourcery
           @emits_event_types = event_types.map(&:to_s)
 
           @emits_event_types.each do |event_type|
-            define_method "emit_#{event_type}_event" do |aggregate_id, body|
+            define_method "emit_#{event_type}" do |aggregate_id, body|
               emit_event(
                 type: event_type,
                 aggregate_id: aggregate_id,

--- a/spec/event_sourcery/event_processing/reactor_spec.rb
+++ b/spec/event_sourcery/event_processing/reactor_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe EventSourcery::EventProcessing::Reactor do
 
       it 'adds methods to emit permitted events' do
         allow(reactor).to receive(:emit_event).with(type: 'echo_event', aggregate_id: 123, body: { a: :b })
-        reactor.emit_echo_event_event(123, { a: :b })
+        reactor.emit_echo_event(123, { a: :b })
       end
 
       it 'can emit events with a hash instead of an event object' do


### PR DESCRIPTION
This PR allows to do this:

```
emit_license_granted_event(aggregate_id, body)
```

instead if this:

```
emit_event(
  type: Events::LICENSE_GRANTED,
  aggregate_id: aggregate_id,
  body: body
)
```