### PR TITLE
Test against Ruby 2.4.0 and 2.3.3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,17 @@
+---
+
+steps:
+  - name: ":ruby: 2.4.0 :rspec:"
+    command: "script/ci_rake.sh"
+    env:
+      RBENV_VERSION: "2.4.0"
+    agents:
+      queue: "market"
+      ruby: "2.4.0"
+  - name: ":ruby: 2.3.3 :rspec:"
+    command: "script/ci_rake.sh"
+    env:
+      RBENV_VERSION: "2.3.3"
+    agents:
+      queue: "market"
+      ruby: "2.3.3"


### PR DESCRIPTION
Test against Ruby 2.4.0 and 2.3.3. We have apps running on Ruby 2.3 and I assume they'll migrate to 2.4 one by one. Let's ensure EventSourcery is compatible with both.

I've taken the liberty of committing the CI config to SCM so changes are transparent.