### PR TITLE
Replace Bignum usage with Integer

### DIFF
--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -14,7 +14,7 @@ module EventSourcery
       attribute :aggregate_id, String
       attribute :type, String
       attribute :body, Hash
-      attribute :version, Bignum
+      attribute :version, Integer
       attribute :created_at, Time
     end
 

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe EventSourcery::Event do
   let(:aggregate_id) { 'aggregate_id' }
   let(:type) { 'type' }
+  let(:version) { 1 }
   let(:body) do
     {
       symbol: "value",
@@ -9,7 +10,7 @@ RSpec.describe EventSourcery::Event do
   let(:uuid) { SecureRandom.uuid }
 
   describe '#initialize' do
-    subject(:initializer) { described_class.new(aggregate_id: aggregate_id, type: type, body: body) }
+    subject(:initializer) { described_class.new(aggregate_id: aggregate_id, type: type, body: body, version: version) }
 
     before do
       allow(EventSourcery::EventBodySerializer).to receive(:serialize)
@@ -36,6 +37,14 @@ RSpec.describe EventSourcery::Event do
       it 'skips serialization of event body' do
         expect(EventSourcery::EventBodySerializer).to_not receive(:serialize)
         initializer
+      end
+    end
+
+    context 'given version is a long string' do
+      let(:version) { '1' * 20 }
+
+      it 'version type is coerced to an integer value, bignum style' do
+        expect(initializer.version).to eq(11_111_111_111_111_111_111)
       end
     end
   end


### PR DESCRIPTION
Bignum is deprecated in Ruby 2.4. We can use Integer instead. Fixes the deprecation notice:

        lib/event_sourcery/event.rb:17: warning: constant ::Bignum is deprecated