### PR TITLE
Cascade when dropping tables in TableOwner#reset

### DIFF
--- a/lib/event_sourcery/event_processing/table_owner.rb
+++ b/lib/event_sourcery/event_processing/table_owner.rb
@@ -28,7 +28,7 @@ module EventSourcery
       def reset
         self.class.tables.keys.each do |table_name|
           if @db_connection.table_exists?(table_name)
-            @db_connection.drop_table(table_name)
+            @db_connection.drop_table(table_name, cascade: true)
           end
         end
         super if defined?(super)


### PR DESCRIPTION
TableOwner#reset can't reliably drop tables if we have dependent tables defined in a TableOwner.

e.g.

```ruby
Class.new do
  prepend EventSourcery::EventProcessing::TableOwner

  def initialize(db_connection)
    @db_connection = db_connection
  end

  table :authors do
    primary_key :id, type: :Integer
    column :uuid, 'UUID'
  end

  table :items do
    foreign_key :authors_id, :authors
    column :created_at, 'timestamp without time zone'
  end
end
```

Adding the `cascade` option fixes this.