### PR TITLE
Allow to compare Event instances

### DIFF
--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -21,5 +21,9 @@ module EventSourcery
     def persisted?
       !id.nil?
     end
+
+    def ==(other)
+      type.to_sym == other.type.to_sym && body == other.body
+    end
   end
 end

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -49,7 +49,23 @@ RSpec.describe EventSourcery::Event do
     end
   end
 
-  context 'equality' do
-    #let(:event_1) { EventSourcery::Event.new(id: 1
+  context '.==' do
+    subject { described_class.new(type: 'Type', body: { a: :b }) }
+
+    it 'is equal to an event with the same type as a symbol and body' do
+      is_expected.to eq described_class.new(type: :Type, body: { a: :b })
+    end
+
+    it 'is equal to an event with the same type as a string and body' do
+      is_expected.to eq described_class.new(type: 'Type', body: { a: :b })
+    end
+
+    it 'is not equal to an event with a different type and the same body' do
+      is_expected.not_to eq described_class.new(type: 'DifferentType', body: { a: :b })
+    end
+
+    it 'is not equal to an event with the same type and a different body' do
+      is_expected.not_to eq described_class.new(type: 'Type', body: { different: :body })
+    end
   end
 end


### PR DESCRIPTION
This code is extracted from Hosted service repo. Originally I wrote it to be able to compare the emitted events with the expected ones in tests with the "standard" Rspec matchers:

```
it 'emits LicenseGranted' do
  expect(emitted_event).to eq(LicenseGranted.new(body: {
    'subscription_id' => 1,
    'theme_id'        => 2,
    'sso_id'          => 'ee287b23-2254-490a-a9f4-72fb35870ce1',
    'granted_at'      => '2016-12-12 12:12:12 UTC'
  }))
end
```
