### PR TITLE
Bump version in preparation for next release

### DIFF
--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,3 +1,3 @@
 module EventSourcery
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
v0.7.0 ➡️ v0.8.0

Although there's a non-backward compatible change here. As we haven't released version 1 this is ok to release with a minor version bump.

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

http://semver.org/#spec-item-4