### PR TITLE
Re-introduce a clutch mode for reactors

### DIFF
--- a/lib/event_sourcery/event_store/memory.rb
+++ b/lib/event_sourcery/event_store/memory.rb
@@ -42,6 +42,10 @@ module EventSourcery
       def get_events_for_aggregate_id(id)
         @events.select { |event| event.aggregate_id == id }
       end
+
+      def subscribe(from_id:, event_types: nil, after_listen: nil, subscription_master:, &block)
+        block.call(@events)
+      end
     end
   end
 end


### PR DESCRIPTION
@warrenseen and I would like to prepose bringing back a clutch mode for reactors. We've re-implemented the old in-memory version so far. We're planning on moving this to an external (Redis?) store next.

TODO:

- [ ] Clean up `process` duplication
- [ ] Redis
- [ ] Specs around the `action` blocks being called