### PR TITLE
Use a transaction level advisory lock in write events

### DIFF
--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -86,7 +86,7 @@ if _lockTable then
     -- integer row ID, so values 1 to the number of ESP's in the system would
     -- be taken if the tracker is running in the same database as your
     -- projections.
-    perform pg_try_advisory_lock(-1);
+    perform pg_advisory_xact_lock(-1);
 end if;
 foreach body IN ARRAY(_bodies)
 loop


### PR DESCRIPTION
The previous version was a session level lock, which would prevent any other connection from writing events after it had ran. Also the previous version was using `try`, of which the return value needs to be checked. This method will pause until the lock is available in the same way that `lock table` does.