### PR TITLE
Fix flakey spec

### DIFF
--- a/spec/event_sourcery/postgres/tracker_spec.rb
+++ b/spec/event_sourcery/postgres/tracker_spec.rb
@@ -82,8 +82,9 @@ RSpec.describe EventSourcery::Postgres::Tracker do
     end
 
     context 'unable to lock tracker row' do
+      let(:db) { new_connection }
+
       it "raises an error" do
-        db = new_connection
         expect {
           tracker = described_class.new(db)
           tracker.setup(processor_name)
@@ -92,12 +93,15 @@ RSpec.describe EventSourcery::Postgres::Tracker do
 
       context 'with obtain_processor_lock: false' do
         it "doesn't raises an error" do
-          db = new_connection
           expect {
             tracker = described_class.new(db, obtain_processor_lock: false)
             tracker.setup(processor_name)
           }.to_not raise_error
         end
+      end
+
+      after do
+        release_advisory_locks(db)
       end
     end
   end

--- a/spec/support/db_helpers.rb
+++ b/spec/support/db_helpers.rb
@@ -46,7 +46,7 @@ module DBHelpers
     EventSourcery::Postgres::Schema.create_projector_tracker(db: pg_connection)
   end
 
-  def release_advisory_locks
+  def release_advisory_locks(connection=pg_connection)
     connection.fetch("SELECT pg_advisory_unlock_all();").to_a
   end
 end


### PR DESCRIPTION
This spec was obtaining the processor lock in a new connection and the release_advisory_locks method was release them on a different connection. Things would fail if this ran before the tracker spec.