### PR TITLE
Console script starts Pry

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,13 +2,5 @@
 
 require "bundler/setup"
 require "event_sourcery"
-
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start
+require "pry"
+Pry.start


### PR DESCRIPTION
We have a convenience script to start a console. Pry is a development dependency.

Let's have the convenience script start a Pry console rather than IRB.