### PR TITLE
Script to demonstrate non-linear insertion of sequence IDs

### DIFF
--- a/script/demonstrate_event_sequence_id_gaps.rb
+++ b/script/demonstrate_event_sequence_id_gaps.rb
@@ -44,12 +44,11 @@
 #
 # Why is this a problem?
 #
-# Consumers of events use the sequence ID to keep track of where they're up to
+# Event stream processors use the sequence ID to keep track of where they're up to
 # in the events table. If a projector processes an event with sequence ID n, it
 # assumes that the next event it needs to process will have a sequence ID > n.
-# This approach doesn't work when sequence IDs are inserted non-linearly, event
-# stream processors would skip events under concurrent writes to the event
-# store as demonstrated with this script.
+# This approach isn't reliable when sequence IDs appear non-linearly, making it
+# possible for event stream processors to skip over events.
 #
 # How does EventSourcery deal with this?
 #


### PR DESCRIPTION
Demonstrates, through brute force, that sequence IDs may not be inserted linearly with concurrent writers & no synchronisation/locking mechanism in place.