### PR TITLE
AggregateRoot & Repository responsibilities refactor

### DIFF
--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -30,7 +30,7 @@ module EventSourcery
 
     attr_reader :changes, :version
 
-    def clear_changes!
+    def clear_changes
       @changes.clear
     end
 

--- a/lib/event_sourcery/repository.rb
+++ b/lib/event_sourcery/repository.rb
@@ -19,7 +19,7 @@ module EventSourcery
       if new_events.any?
         event_sink.sink(new_events, expected_version: aggregate.version - new_events.count)
       end
-      aggregate.clear_changes!
+      aggregate.clear_changes
     end
 
     private

--- a/spec/event_sourcery/aggregate_root_spec.rb
+++ b/spec/event_sourcery/aggregate_root_spec.rb
@@ -118,12 +118,12 @@ RSpec.describe EventSourcery::AggregateRoot do
 
     context 'when changes are cleared' do
       it 'has no changes' do
-        aggregate.clear_changes!
+        aggregate.clear_changes
         expect(aggregate.changes).to eq []
       end
 
       it "maintains it's version" do
-        aggregate.clear_changes!
+        aggregate.clear_changes
         expect(aggregate.version).to eq 1
       end
     end

--- a/spec/event_sourcery/repository_spec.rb
+++ b/spec/event_sourcery/repository_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe EventSourcery::Repository do
 
   describe '#save' do
     let(:version) { 20 }
-    let(:aggregate) { double(EventSourcery::AggregateRoot, changes: changes, id: aggregate_id, version: version, clear_changes!: nil) }
+    let(:aggregate) { double(EventSourcery::AggregateRoot, changes: changes, id: aggregate_id, version: version, clear_changes: nil) }
     let(:event_sink) { double(EventSourcery::EventStore::EventSink, sink: nil) }
     let(:event_source) { double(EventSourcery::EventStore::EventSink, get_events_for_aggregate_id: nil) }
     subject(:repository) { EventSourcery::Repository.new(event_source: event_source, event_sink: event_sink) }


### PR DESCRIPTION
We discussed this briefly in the last ES brown bag.

Current state:

- the `Repository` is responsible for getting the events for an aggregate and loading it
- the `AggregateRoot` is responsible for persisting it's new events in the event sink which is a constructor dependency

This feels wrong to me. Either AggregateRoot should do both saving and loading, or repository should be both saving and loading.

Proposed changes:

- the Repository is responsible for saving aggregates in addition to loading them 😲  
- the AggregateRoot exposes it's changes / new events to facilitate this and testing of aggregates

Usage in a command handler would look something like this:

```ruby
class MyCommandHandler
  include CommandHandler
  # in CommandHandler module
  # def initialize(repository:) # a Repository instance

  def handle(command)
    with_aggregate(Person, command.person_uuid) do |person|
      person.provide_w9_form(...)
    end
  end

  private

  # in CommandHandler module
  def with_aggregate(aggregate_class, id)
    aggregate = repository.load(aggregate_class, command.aggregate_id)
    yield aggregate
    repository.save(aggregate)
  end
end
```

I dislike referencing the `Repository` constant from within handlers so the example above has the repository instance constructor injected.