### PR TITLE
Alternative aggregate interface - process_new_events block

### DIFF
--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -28,9 +28,10 @@ module EventSourcery
       load_history(events)
     end
 
-    attr_reader :changes, :version
+    attr_reader :version
 
-    def clear_changes
+    def process_new_events
+      yield @changes if @changes.any?
       @changes.clear
     end
 

--- a/lib/event_sourcery/repository.rb
+++ b/lib/event_sourcery/repository.rb
@@ -15,11 +15,9 @@ module EventSourcery
     end
 
     def save(aggregate)
-      new_events = aggregate.changes
-      if new_events.any?
+      aggregate.process_new_events do |new_events|
         event_sink.sink(new_events, expected_version: aggregate.version - new_events.count)
       end
-      aggregate.clear_changes
     end
 
     private

--- a/spec/event_sourcery/repository_spec.rb
+++ b/spec/event_sourcery/repository_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe EventSourcery::Repository do
     let(:event_source) { double(EventSourcery::EventStore::EventSink, get_events_for_aggregate_id: nil) }
     subject(:repository) { EventSourcery::Repository.new(event_source: event_source, event_sink: event_sink) }
 
+    before do
+      if changes.any?
+        allow(aggregate).to receive(:process_new_events).and_yield(changes)
+      else
+        allow(aggregate).to receive(:process_new_events)
+      end
+    end
+
     context 'when there are no changes' do
       let(:changes) { [] }
 


### PR DESCRIPTION
Following on from the discussion in https://github.com/envato/event_sourcery/pull/121

This is a proposed alternative to the `#changes` and `#clear_changes` interface that was discussed in the above PR. I'm not proposing this myself, I prefer the interface in the original PR.