### PR TITLE
Document steps to release a new version of the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Then you can run the test suite with rspec:
 rspec
 ```
 
+### Release
+
+To release a new version:
+
+1. Update the version number in `lib/event_sourcery/version.rb`
+2. Get this change onto master via the normal PR process
+3. Run `gem_push=false be rake release`, this will create a git tag for the
+   version, push tags up to GitHub, and package the code in a `.gem` file.
+4. Manually upload the generated gem file (`pkg/event_sourcery-#{version}.gem`) to
+   [rubygems.envato.com](https://rubygems.envato.com).
+
 ## Resources
 
 Not sure what Event Sourcing (ES), Command Query Responsibility Segregation (CQRS), or even Domain-Driven Design (DDD) are? Here are a few links to get you started:


### PR DESCRIPTION
Similar release steps to those in [event_sourcery-postgres](https://github.com/envato/event_sourcery-postgres/pull/4).