### PR TITLE
Add `shutdown!` method to PollWaiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.2] - 2017-5-29
+### Fixed
+- Fixed: default poll waiter now implements `shutdown!`
+
 ## [0.11.0] - 2017-5-29
 ### Fixed
 - Use `processor.class.name` to set ESP process name

--- a/lib/event_sourcery/event_store/poll_waiter.rb
+++ b/lib/event_sourcery/event_store/poll_waiter.rb
@@ -14,5 +14,8 @@ module EventSourcery
         end
       end
     end
+
+    def shutdown!
+    end
   end
 end

--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,3 +1,3 @@
 module EventSourcery
-  VERSION = "0.11.1"
+  VERSION = "0.11.2"
 end


### PR DESCRIPTION
### Context

Whenever `start` is called on an instance of `EventSourcery::EventStore::Subscription` and an error is raised, `shutdown!` will be called on its PollWaiter(https://github.com/envato/event_sourcery/blob/master/lib/event_sourcery/event_store/subscription.rb#L27)

However, if the default PollWaiter class is used to initiate `EventSourcery::EventStore::Subscription`, it will raise a NoMethodError as `shutdown!` is not defined.

This would not be an issue for `event_sourcery-postgres` users as it uses `EventSourcery::Postgres::OptimisedEventPollWaiter`, which has `shutdown!` defined