### PR TITLE
Remove `#shutdown!` from PollWaiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.12.0] - 2017-6-1
+### Removed
+- Removed usage `#shutdown!` as it should be a private method within custom PollWaiters.
+  An example of how event_sourcery-postgres has implemented `#shutdown!` can be
+  found [here](https://github.com/envato/event_sourcery-postgres/pull/5)
+  
+
 ## [0.11.2] - 2017-5-29
 ### Fixed
 - Fixed: default poll waiter now implements `shutdown!`

--- a/lib/event_sourcery/event_store/poll_waiter.rb
+++ b/lib/event_sourcery/event_store/poll_waiter.rb
@@ -14,8 +14,5 @@ module EventSourcery
         end
       end
     end
-
-    def shutdown!
-    end
   end
 end

--- a/lib/event_sourcery/event_store/subscription.rb
+++ b/lib/event_sourcery/event_store/subscription.rb
@@ -19,13 +19,8 @@ module EventSourcery
 
       def start
         catch(:stop) do
-          begin
-            @poll_waiter.poll do
-              read_events
-            end
-          rescue => e
-            @poll_waiter.shutdown!
-            raise
+          @poll_waiter.poll do
+            read_events
           end
         end
       end

--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,3 +1,3 @@
 module EventSourcery
-  VERSION = "0.11.2"
+  VERSION = "0.12.0"
 end

--- a/spec/event_sourcery/event_store/subscription_spec.rb
+++ b/spec/event_sourcery/event_store/subscription_spec.rb
@@ -12,9 +12,6 @@ class TestPoller
       after_poll_callback.call
     end
   end
-
-  def shutdown!
-  end
 end
 
 RSpec.describe EventSourcery::EventStore::Subscription do
@@ -71,18 +68,6 @@ RSpec.describe EventSourcery::EventStore::Subscription do
       expect(@event_batches.count).to eq 2
       expect(@event_batches.first.map(&:type)).to eq ['item_added', 'item_removed']
       expect(@event_batches.last.map(&:type)).to eq ['item_added']
-    end
-  end
-
-  context 'when an exception occurs during event polling' do
-    before do
-      allow(waiter).to receive(:poll).and_raise 'event_poll_error'
-    end
-
-    it 'tells the poll waiter to shutdown its thread' do
-      expect(waiter).to receive(:shutdown!)
-      event_store.sink(new_event)
-      expect { subscription.start }.to raise_error 'event_poll_error'
     end
   end
 end


### PR DESCRIPTION
Following the discussion from https://github.com/envato/event_sourcery/pull/133, it was agreed that it would be cleaner to remove `#shutdown!` the poll waiter's interface. It doesn't need to be in the default PollWaiter and the Postgres version need not expose it either (Instead it should be a private method)

Related: https://github.com/envato/event_sourcery-postgres/pull/5