### PR TITLE
Rename event_store to event_source in esp process

### DIFF
--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -2,11 +2,11 @@ module EventSourcery
   module EventProcessing
     class ESPProcess
       def initialize(event_processor:,
-                     event_store:,
+                     event_source:,
                      subscription_master: EventStore::SignalHandlingSubscriptionMaster.new
                     )
         @event_processor = event_processor
-        @event_store = event_store
+        @event_source = event_source
         @subscription_master = subscription_master
       end
 
@@ -34,7 +34,7 @@ module EventSourcery
       end
 
       def subscribe_to_event_stream
-        @event_processor.subscribe_to(@event_store,
+        @event_processor.subscribe_to(@event_source,
                                       subscription_master: @subscription_master)
       end
     end

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -4,11 +4,11 @@ module EventSourcery
     # EventSourcery.config.postgres.event_store_database.disconnect
     class ESPRunner
       def initialize(event_processors:,
-                     event_store:,
+                     event_source:,
                      max_seconds_for_processes_to_terminate: 30,
                      shutdown_requested: false)
         @event_processors = event_processors
-        @event_store = event_store
+        @event_source = event_source
         @pids = []
         @max_seconds_for_processes_to_terminate = max_seconds_for_processes_to_terminate
         @shutdown_requested = shutdown_requested
@@ -48,7 +48,7 @@ module EventSourcery
       def start_process(event_processor)
         process = ESPProcess.new(
           event_processor: event_processor,
-          event_store: @event_store
+          event_source: @event_source
         )
         @pids << Process.fork { process.start }
       end

--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -96,9 +96,9 @@ module EventSourcery
         self.class.processes?(event_type)
       end
 
-      def subscribe_to(event_store, subscription_master: EventStore::SignalHandlingSubscriptionMaster.new)
+      def subscribe_to(event_source, subscription_master: EventStore::SignalHandlingSubscriptionMaster.new)
         setup
-        event_store.subscribe(from_id: last_processed_event_id + 1,
+        event_source.subscribe(from_id: last_processed_event_id + 1,
                               event_types: processes_event_types,
                               subscription_master: subscription_master) do |events|
           process_events(events, subscription_master)

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -2,14 +2,14 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
   subject(:esp_process) do
     described_class.new(
       event_processor: esp,
-      event_store: event_store,
+      event_source: event_source,
       subscription_master: subscription_master,
     )
   end
   let(:esp) { spy(:esp, processor_name: processor_name, class: esp_class) }
   let(:esp_class) { double(name: 'SomeApp::Reactors::SomeReactor') }
   let(:processor_name) { 'processor_name' }
-  let(:event_store) { spy(:event_store) }
+  let(:event_source) { spy(:event_source) }
   let(:subscription_master) { spy(EventSourcery::EventStore::SignalHandlingSubscriptionMaster) }
   let(:error_handler) { double }
 

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -2,12 +2,12 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
   subject(:esp_runner) do
     described_class.new(
       event_processors: event_processors,
-      event_store: event_store,
+      event_source: event_source,
       max_seconds_for_processes_to_terminate: 0.01,
       shutdown_requested: true
     )
   end
-  let(:event_store) { spy(:event_store) }
+  let(:event_source) { spy(:event_source) }
   let(:event_processors) { [esp] }
   let(:esp) { spy(:esp, processor_name: processor_name) }
   let(:processor_name) { 'processor_name' }
@@ -37,7 +37,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         .to have_received(:new)
         .with(
           event_processor: esp,
-          event_store: event_store,
+          event_source: event_source,
         )
       expect(esp_process).to have_received(:start)
     end


### PR DESCRIPTION
`event_source` and `event_sink` are two abstractions we have around `event_store`.
Event stream processor should use `event_source` to subscribe and read events, and use `event_sink` to emit new events.
Let's replace `event_store` in EventProcessing namespace with `event_source` 