### PR TITLE
Allow EventProcessingError to report the originating error message

### DIFF
--- a/lib/event_sourcery/errors.rb
+++ b/lib/event_sourcery/errors.rb
@@ -11,5 +11,9 @@ module EventSourcery
     def initialize(event)
       @event = event
     end
+
+    def message
+      cause&.message
+    end
   end
 end


### PR DESCRIPTION
I had a EventProcessingError showing up in RSS cukes. The absence of an error message made this harder to debug than it should have been. I've set the message to the message of the original cause, if there is one.

This is what I see with the fix in place:
```
    When the user requests to start a new subscription                               # features/step_definitions/subscription_requests.rb:29
      Recurly.api_key not configured (EventSourcery::EventProcessingError)
      /Users/macosgrove/src/event_sourcery/lib/event_sourcery/event_processing/event_stream_processor.rb:37:in `rescue in process'
...
      ./features/support/event_sourcery_helpers.rb:49:in `catch_up_esp'
```

compared to:
```
    When the user requests to start a new subscription                               # features/step_definitions/subscription_requests.rb:29
      EventSourcery::EventProcessingError (EventSourcery::EventProcessingError)
      ./features/support/event_sourcery_helpers.rb:49:in `catch_up_esp'
```
previously.
