### PR TITLE
Implement Event#hash method

### DIFF
--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -32,6 +32,10 @@ module EventSourcery
       !id.nil?
     end
 
+    def hash
+      [self.class, uuid].hash
+    end
+
     def eql?(other)
       instance_of?(other.class) && uuid.eql?(other.uuid)
     end

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -108,6 +108,58 @@ RSpec.describe EventSourcery::Event do
     end
   end
 
+  describe '#hash' do
+    subject(:hash) { event.hash }
+
+    context 'given an Event with UUID' do
+      let(:event) { EventSourcery::Event.new(uuid: event_uuid) }
+      let(:event_uuid) { SecureRandom.uuid }
+
+      it { should be_an Integer }
+
+      context 'compared to an Event with same UUID' do
+        let(:other) { EventSourcery::Event.new(uuid: event_uuid) }
+        it { should eq other.hash }
+      end
+
+      context 'compared to an Event with same UUID (uppercase)' do
+        let(:other) { EventSourcery::Event.new(uuid: event_uuid.upcase) }
+        it { should eq other.hash }
+      end
+
+      context 'compared to an event with different UUID' do
+        let(:other) { EventSourcery::Event.new(uuid: SecureRandom.uuid) }
+        it { should_not eq other.hash }
+      end
+
+      context 'compared to an event without UUID' do
+        let(:other) { EventSourcery::Event.new(uuid: nil) }
+        it { should_not eq other.hash }
+      end
+
+      context 'compared to an ItemAdded event with same UUID' do
+        let(:other) { ItemAdded.new(uuid: event_uuid) }
+        it { should_not eq other.hash }
+      end
+    end
+
+    context 'given an Event without UUID' do
+      let(:event) { EventSourcery::Event.new(uuid: nil) }
+
+      it { should be_an Integer }
+
+      context 'compared to an Event without UUID' do
+        let(:other) { EventSourcery::Event.new(uuid: nil) }
+        it { should eq other.hash }
+      end
+
+      context 'compared to an event with UUID' do
+        let(:other) { EventSourcery::Event.new(uuid: SecureRandom.uuid) }
+        it { should_not eq other.hash }
+      end
+    end
+  end
+
   describe '#eql?' do
     subject(:eql?) { event.eql?(other) }
 


### PR DESCRIPTION
From the description of `#hash` in the [Ruby docs](http://ruby-doc.org/core-2.4.1/Object.html#method-i-hash):

> This function must have the property that `a.eql?(b)` implies `a.hash == b.hash`.

Now `Event#hash` satisfies this constraint as it has been brought in line with our custom `Event#eql?` implementation.

This should avoid any weirdness when using Event instances as hash keys.