### PR TITLE
Fixing the no method error iso8601 need the time package

### DIFF
--- a/lib/event_sourcery.rb
+++ b/lib/event_sourcery.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'securerandom'
+require 'time'
 
 require 'event_sourcery/version'
 require 'event_sourcery/event'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'event_sourcery'
 require 'pry'
-require 'time'
 require 'event_sourcery/rspec/event_store_shared_examples'
 
 Dir.glob(File.dirname(__FILE__) + '/support/**/*.rb') { |f| require f }


### PR DESCRIPTION
My specs were failing because of a `NoMethodError: undefined method `iso8601'` in a bunch of specs. Just needed to add the time package in the specs.