### PR TITLE
Remove unused `RejectedCommandError`

### DIFF
--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -1,7 +1,6 @@
 module EventSourcery
   module AggregateRoot
     UnknownEventError = Class.new(RuntimeError)
-    RejectedCommandError = Class.new(RuntimeError)
 
     def self.included(base)
       base.extend(ClassMethods)


### PR DESCRIPTION
This error type is not used internally. And outside of the library, we seems to be using application specific error types (such as `Payables::Errors::RejectedCommandError` and `Identity::Errors::RejectedCommandError`). So it seems redundant :man_shrugging: 