### PR TITLE
Fixes backtrace output when errors occur

### DIFF
--- a/lib/event_sourcery/event_processing/error_handlers/error_handler.rb
+++ b/lib/event_sourcery/event_processing/error_handlers/error_handler.rb
@@ -10,7 +10,7 @@ module EventSourcery
 
         def report_error(error)
           error = error.cause if error.instance_of?(EventSourcery::EventProcessingError)
-          EventSourcery.logger.error("Processor #{@processor_name} died with #{error}.\\n #{error.backtrace.join('\n')}")
+          EventSourcery.logger.error("Processor #{@processor_name} died with #{error}.\\n #{error.backtrace.join("\n")}")
 
           EventSourcery.config.on_event_processor_error.call(error, @processor_name)
         end

--- a/lib/event_sourcery/event_processing/error_handlers/error_handler.rb
+++ b/lib/event_sourcery/event_processing/error_handlers/error_handler.rb
@@ -10,7 +10,7 @@ module EventSourcery
 
         def report_error(error)
           error = error.cause if error.instance_of?(EventSourcery::EventProcessingError)
-          EventSourcery.logger.error("Processor #{@processor_name} died with #{error}.\\n #{error.backtrace.join("\n")}")
+          EventSourcery.logger.error("Processor #{@processor_name} died with #{error}.\n#{error.backtrace.join("\n")}")
 
           EventSourcery.config.on_event_processor_error.call(error, @processor_name)
         end

--- a/spec/event_sourcery/event_processing/error_handlers/constant_retry_spec.rb
+++ b/spec/event_sourcery/event_processing/error_handlers/constant_retry_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::ConstantRetry do
       end
 
       it 'logs the original error' do
-        expect(logger).to have_received(:error).thrice.with("Processor #{processor_name} died with OriginalError.\\n back\\ntrace")
+        expect(logger).to have_received(:error).thrice.with("Processor #{processor_name} died with OriginalError.\nback\ntrace")
       end
 
       it 'calls on_event_processor_error with error and processor name' do

--- a/spec/event_sourcery/event_processing/error_handlers/exponential_backoff_retry_spec.rb
+++ b/spec/event_sourcery/event_processing/error_handlers/exponential_backoff_retry_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::ExponentialBackoff
       let(:error) { EventSourcery::EventProcessingError.new(event) }
 
       it 'logs the original error' do
-        expect(logger).to have_received(:error).thrice.with("Processor #{processor_name} died with OriginalError.\\n back\\ntrace")
+        expect(logger).to have_received(:error).thrice.with("Processor #{processor_name} died with OriginalError.\nback\ntrace")
       end
 
       it 'calls on_event_processor_error with error and processor name' do

--- a/spec/event_sourcery/event_processing/error_handlers/no_retry_spec.rb
+++ b/spec/event_sourcery/event_processing/error_handlers/no_retry_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::NoRetry do
       let(:error) { EventSourcery::EventProcessingError.new(event) }
 
       it 'logs the original error' do
-        expect(logger).to have_received(:error).once.with("Processor #{processor_name} died with OriginalError.\\n back\\ntrace")
+        expect(logger).to have_received(:error).once.with("Processor #{processor_name} died with OriginalError.\nback\ntrace")
       end
 
       it 'calls on_event_processor_error with error and processor name' do


### PR DESCRIPTION
Tiny PR to make errors easier to read when they occur. It's currently just outputting everything onto a single line