### PR TITLE
Add causation_id to event class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- The core Event class accepts `causation_id` to allow event stores to
+  add support for tracking causation ids with events.
+
 ### Removed
 - The `processing_event` method from the memory tracker. It was intended to
   be a mechanism to wrap processing and tracker updates which appears to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - The core Event class accepts `causation_id` to allow event stores to
   add support for tracking causation ids with events.
+- The core Memory event store saves the `causation_id`.
+- The event store shared RSpec examples specify event stores should save
+  the `causation_id`.
 
 ### Removed
 - The `processing_event` method from the memory tracker. It was intended to

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -8,7 +8,7 @@ module EventSourcery
       end
     end
 
-    attr_reader :id, :uuid, :aggregate_id, :type, :body, :version, :created_at, :correlation_id
+    attr_reader :id, :uuid, :aggregate_id, :type, :body, :version, :created_at, :correlation_id, :causation_id
 
     def initialize(id: nil,
                    uuid: SecureRandom.uuid,
@@ -17,7 +17,8 @@ module EventSourcery
                    body: nil,
                    version: nil,
                    created_at: nil,
-                   correlation_id: nil)
+                   correlation_id: nil,
+                   causation_id: nil)
       @id = id
       @uuid = uuid && uuid.downcase
       @aggregate_id = aggregate_id
@@ -26,6 +27,7 @@ module EventSourcery
       @version = version ? Integer(version) : nil
       @created_at = created_at
       @correlation_id = correlation_id
+      @causation_id = causation_id
     end
 
     def persisted?

--- a/lib/event_sourcery/event_store/memory.rb
+++ b/lib/event_sourcery/event_store/memory.rb
@@ -24,7 +24,8 @@ module EventSourcery
             version: next_version(event.aggregate_id),
             body: serialized_body,
             created_at: event.created_at || Time.now.utc,
-            uuid: event.uuid
+            uuid: event.uuid,
+            causation_id: event.causation_id,
           )
         end
         true

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe EventSourcery::Event do
       expect(event.correlation_id).to be_nil
     end
 
+    it 'assigns a given causation_id' do
+      uuid = SecureRandom.uuid
+      event = described_class.new(causation_id: uuid)
+      expect(event.causation_id).to eq uuid
+    end
+
+    it 'has a nil causation_id if none is given' do
+      event = described_class.new
+      expect(event.causation_id).to be_nil
+    end
+
     context 'event body is nil' do
       let(:body) { nil }
 


### PR DESCRIPTION
Add `causation_id` to core `Event` class. We can then update the postgres adapter to populate this with the UUID of the event being reacted to in reactors. This will be a replacement for the `driven_by_event_id` currently being populated in event bodies.