### PR TITLE
Stringify aggregate_id when loading aggregate from event_store

### DIFF
--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -20,7 +20,7 @@ module EventSourcery
     end
 
     def initialize(id, events, on_unknown_event: EventSourcery.config.on_unknown_event)
-      @id = id
+      @id = id.to_str
       @version = 0
       @on_unknown_event = on_unknown_event
       @changes = []

--- a/lib/event_sourcery/event_store/memory.rb
+++ b/lib/event_sourcery/event_store/memory.rb
@@ -46,7 +46,8 @@ module EventSourcery
       end
 
       def get_events_for_aggregate_id(id)
-        @events.select { |event| event.aggregate_id == id }
+        stringified_id = id.to_str
+        @events.select { |event| event.aggregate_id == stringified_id }
       end
 
       def next_version(aggregate_id)

--- a/spec/event_sourcery/repository_spec.rb
+++ b/spec/event_sourcery/repository_spec.rb
@@ -15,16 +15,26 @@ RSpec.describe EventSourcery::Repository do
   }
   let(:events) { [new_event(type: :item_added, aggregate_id: aggregate_id)] }
 
-  describe '#load' do
-    before do
-      events.each do |event|
-        event_store.sink(event)
-      end
-    end
+  describe '.load' do
+    RSpec.shared_examples 'news up an aggregate and loads history' do
+      let(:added_events) { event_store.get_events_for_aggregate_id(aggregate_id) }
 
-    it 'news up an aggregate and loads history' do
-      aggregate = described_class.load(aggregate_class, aggregate_id, event_source: event_store, event_sink: event_sink)
-      expect(aggregate.item_added_events).to eq event_store.get_events_for_aggregate_id(aggregate_id)
+      subject(:aggregate) do
+        described_class.load(aggregate_class, uuid, event_source: event_store, event_sink: event_sink)
+      end
+
+      specify { expect(aggregate.item_added_events).to eq(added_events) }
+      context 'when aggregate_id is a string' do
+        include_examples 'news up an aggregate and loads history' do
+          let(:uuid) { aggregate_id }
+        end
+      end
+
+      context 'when aggregate_id is convertible to a string' do
+        include_examples 'news up an aggregate and loads history' do
+          let(:uuid) { double(to_str: aggregate_id) }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR is based on https://github.com/envato/event_sourcery/pull/101/files

I'll add a follow up PR to `event_sourcery-postgres`.