### PR TITLE
Add Event#with and Event#to_h methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The core Event class accepts `causation_id` to allow event stores to
   add support for tracking causation ids with events.
 - The core Memory event store saves the `causation_id`.
+- Added `Event#to_h` method. This returns a hash of the event attributes.
+
+### Changed
 - The event store shared RSpec examples specify event stores should save
   the `causation_id`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   add support for tracking causation ids with events.
 - The core Memory event store saves the `causation_id`.
 - Added `Event#to_h` method. This returns a hash of the event attributes.
+- Added `Event#with` method. This provides a way to create a new event
+  identical to the old event except for the provided changes.
 
 ### Changed
 - The event store shared RSpec examples specify event stores should save

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -46,6 +46,10 @@ module EventSourcery
       id <=> other.id if other.is_a? Event
     end
 
+    def with(**attributes)
+      self.class.new(**to_h.merge!(attributes))
+    end
+
     def to_h
       {
         id:             id,

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -45,5 +45,19 @@ module EventSourcery
     def <=>(other)
       id <=> other.id if other.is_a? Event
     end
+
+    def to_h
+      {
+        id:             id,
+        uuid:           uuid,
+        aggregate_id:   aggregate_id,
+        type:           type,
+        body:           body,
+        version:        version,
+        created_at:     created_at,
+        correlation_id: correlation_id,
+        causation_id:   causation_id,
+      }
+    end
   end
 end

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -119,6 +119,16 @@ RSpec.describe EventSourcery::Event do
     end
   end
 
+  describe '#to_h' do
+    %i[id uuid aggregate_id type body version created_at correlation_id causation_id].each do |attribute|
+      it "includes #{attribute}" do
+        value = %i[id version].include?(attribute) ? 42 : '42'
+        event = EventSourcery::Event.new(attribute => value)
+        expect(event.to_h).to include(attribute => value)
+      end
+    end
+  end
+
   describe '#hash' do
     subject(:hash) { event.hash }
 

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -119,6 +119,52 @@ RSpec.describe EventSourcery::Event do
     end
   end
 
+  describe '#with' do
+    subject(:with) { original_event.with(**changes) }
+
+    let(:original_event) { EventSourcery::Event.new(**original_attributes) }
+    let(:original_attributes) do
+      {
+        id:             73,
+        uuid:           SecureRandom.uuid,
+        aggregate_id:   SecureRandom.uuid,
+        type:           'type',
+        body:           { 'attr' => 'value' },
+        version:        89,
+        created_at:     Time.now.utc,
+        correlation_id: SecureRandom.uuid,
+        causation_id:   SecureRandom.uuid,
+      }
+    end
+    let(:changes) do
+      {
+        causation_id: SecureRandom.uuid,
+      }
+    end
+
+    it 'returns a new event' do
+      expect(with).to_not be(original_event)
+    end
+
+    it 'makes the changes to the new event' do
+      changes.each do |attribute, value|
+        expect(with.send(attribute)).to eq(value)
+      end
+    end
+
+    it 'maintains the original, unchanged values on the new event' do
+      original_attributes.each do |attribute, value|
+        expect(with.send(attribute)).to(eq(value)) unless changes.include?(attribute)
+      end
+    end
+
+    it 'does not mutate the original event' do
+      original_attributes.each do |attribute, value|
+        expect(original_event.send(attribute)).to(eq(value))
+      end
+    end
+  end
+
   describe '#to_h' do
     %i[id uuid aggregate_id type body version created_at correlation_id causation_id].each do |attribute|
       it "includes #{attribute}" do


### PR DESCRIPTION
### Context

As part of the feature to add `causation_id` to events emitted from reactors I found it's not so easy. We don't want to mutate events, instead we want an easy way to duplicate events while making the specified changes.

### Changes

* Added `Event#to_h` method. Pretty straight-forward: returns a hash of the event attributes.

* Added `Event#with` method. This provides a way to create a new event identical to the old event except for the provided changes. Example:

    ```ruby
    old_event = EventSourcery::Event.new(type: "item_added", causation_id: nil)
    new_event = old_event.with(causation_id: "05781bd6-796a-4a58-8573-b109f683fd99")

    new_event.type # => "item_added"
    new_event.causation_id # => "05781bd6-796a-4a58-8573-b109f683fd99"

    old_event.type # => "item_added"
    old_event.causation_id # => nil
    ```

  Of course, `with` can accept any number of event attributes:

    ```ruby
    new_event = old_event.with(id: 42, version: 77, body: { 'attr' => 'value' })
    ```
