### PR TITLE
Memory event store saves correlation_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - The core Event class accepts `causation_id` to allow event stores to
   add support for tracking causation ids with events.
-- The core Memory event store saves the `causation_id`.
+- The core Memory event store saves the `causation_id` and `correlation_id`.
+
+### Changed
 - The event store shared RSpec examples specify event stores should save
-  the `causation_id`.
+  the `causation_id` and `correlation_id`.
 
 ### Removed
 - The `processing_event` method from the memory tracker. It was intended to

--- a/lib/event_sourcery/event_store/memory.rb
+++ b/lib/event_sourcery/event_store/memory.rb
@@ -25,6 +25,7 @@ module EventSourcery
             body: serialized_body,
             created_at: event.created_at || Time.now.utc,
             uuid: event.uuid,
+            correlation_id: event.correlation_id,
             causation_id: event.causation_id,
           )
         end

--- a/lib/event_sourcery/rspec/event_store_shared_examples.rb
+++ b/lib/event_sourcery/rspec/event_store_shared_examples.rb
@@ -1,8 +1,9 @@
 RSpec.shared_examples 'an event store' do
   let(:aggregate_id) { SecureRandom.uuid }
 
-  def new_event(aggregate_id: SecureRandom.uuid, type: 'test_event', body: {}, id: nil, version: 1,
-                created_at: nil, uuid: SecureRandom.uuid, causation_id: SecureRandom.uuid)
+  def new_event(aggregate_id: SecureRandom.uuid, type: 'test_event', body: {},
+                id: nil, version: 1, created_at: nil, uuid: SecureRandom.uuid,
+                correlation_id: SecureRandom.uuid, causation_id: SecureRandom.uuid)
     EventSourcery::Event.new(id: id,
                              aggregate_id: aggregate_id,
                              type: type,
@@ -10,6 +11,7 @@ RSpec.shared_examples 'an event store' do
                              version: version,
                              created_at: created_at,
                              uuid: uuid,
+                             correlation_id: correlation_id,
                              causation_id: causation_id)
   end
 
@@ -46,6 +48,13 @@ RSpec.shared_examples 'an event store' do
       event = new_event(causation_id: causation_id)
       event_store.sink(event)
       expect(event_store.get_next_from(1, limit: 1).first.causation_id).to eq(causation_id)
+    end
+
+    it 'saves the correlation_id' do
+      correlation_id = SecureRandom.uuid
+      event = new_event(correlation_id: correlation_id)
+      event_store.sink(event)
+      expect(event_store.get_next_from(1, limit: 1).first.correlation_id).to eq(correlation_id)
     end
 
     it 'writes multiple events' do


### PR DESCRIPTION
### Context

Back in #125 @stevehodgkiss added the `correlation_id` to the `Event` class.

### Change

Now we expect all event stores should persist and load this event attribute so the shared RSpec examples have been updated to specify this. The memory Event Store is updated to comply.