### PR TITLE
Remove processes_events from Event Stream Processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- Remove `processes_events` and related methods in favour of `process` class
+  method. You can no longer override `process` and subscribe to all events.
+  If you want to subscribe to all events you can call the `process` class
+  method with no events.
+
+      process do |event|
+        # all events will be subscribed to
+      end
+
+      process Foobar do |event|
+        # Foobar events will be subscribed to
+      end
 
 ## [0.15.0] - 2017-11-29
 ### Added

--- a/lib/event_sourcery/errors.rb
+++ b/lib/event_sourcery/errors.rb
@@ -1,9 +1,9 @@
 module EventSourcery
   Error = Class.new(StandardError)
   UnableToLockProcessorError = Class.new(Error)
-  UnableToProcessEventError = Class.new(Error)
   ConcurrencyError = Class.new(Error)
   AtomicWriteToMultipleAggregatesNotSupported = Class.new(Error)
+  MultipleCatchAllHandlersDefined = Class.new(Error)
 
   class EventProcessingError < Error
     attr_reader :event, :processor

--- a/lib/event_sourcery/memory/projector.rb
+++ b/lib/event_sourcery/memory/projector.rb
@@ -9,7 +9,6 @@ module EventSourcery
           alias_method :project, :process
           class << self
             alias_method :project, :process
-            alias_method :projects_events, :processes_events
             alias_method :projector_name, :processor_name
           end
         end


### PR DESCRIPTION
This PR removes support for the older syntax of defining a generic `process` method on event processors and using `processes_events` to control what events should trigger the `process` method to be called.

I've removed this functionality in favour of using the `process EventName do |event|` DSL.

Previously you could set up an event stream processor with a `process`
method defined and tell event sourcery what events to process using the
`processes_events` method:

``` ruby
class MyProjector
  include EventSourcery::EventProcessing::EventStreamProcessor

  processes_events :item_added

  def process(event)
    # only ItemAdded events will be processed.
  end
end
```

``` ruby
class MyProjector
  include EventSourcery::EventProcessing::EventStreamProcessor

  processes_all_events

  def process(event)
    # all events will be processed.
  end
end
```

We're removing that functionality in favour of the newer DSL.

``` ruby
class MyProjector
  include EventSourcery::EventProcessing::EventStreamProcessor

  process ItemAdded do |event|
    # only ItemAdded events will be processed.
  end
end
```

``` ruby
class MyProjector
  include EventSourcery::EventProcessing::EventStreamProcessor

  process do |event|
    # all events will be processed.
  end
end
```
