### PR TITLE
Bump version ready for the next release

### DIFF
--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,3 +1,3 @@
 module EventSourcery
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.14.0'.freeze
 end


### PR DESCRIPTION
### Context

`event_sourcery-postgres` makes will make use of features introduced in this version. We should indicate this with a constraint in its gem file. First we need to give `event_sourcery` a new version