### PR TITLE
Slack build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
-  - 2.3
-  - 2.4
+- 2.2
+- 2.3
+- 2.4
 before_install:
-  - gem install bundler
+- gem install bundler
+notifications:
+  slack:
+    on_pull_requests: false
+    on_success: change
+    on_failure: always
+    rooms:
+      secure: sCciUO0p3+nLeNUgdcPH2p7i5Lrw454UJWqDIp9o8d7FzGeYdZdJ+YYDftYBMEM1ousMSLEF1mqJJF3I6itap8Xies5S3Nik8etOi1Gm56gzHUAhsSWikfsoowR+TFP2KKa2jG505QD9QYRvKboPVt3VFdSRk12ia/0TnaHaSdfHLbIiWqNrtS+RIKaDWasLL4Pbtq3UkllYRW1tbBL0kWL71KgCBhrB78xClvsauFv5r7R7TQfoCTGWO19vM+qNAzBswwSdwAuBm5JfEowbzt+OBKNDXU8pO91GxlTJPS14UoGP/PgqqqtorX4pSA1oW4g+ZI12pCRU77GK+tTGe1DEUGVwzJ6EL6s0cuLdh9cVZ1DQEOxWQmIM2HAbWYbyS0YRON48+337f/48W3rr1dYchveUJIowOaaX7xR+knxNSHfadK7tiJY3/1otPCHLssgxDx3myybFW8X5KL9D9Z3HvqGsG/oRyDxorkPoM+Uiraf0R5fNKZXX/6bVdwIhpWr4dwgG5M1oDCqedtq5KegcjHbYLkdCYodeqDx+YtFJp5po/4aqqVO3b1l7nPP2H4syxsjlTeZrD3fWJNwUCiE1HBwUHKbatYICvo7AbdLiSgR/3x1BWF+AiUsRp5QR0I357rexfX7F4zv27RlGhtdlHHd6vtcrZ7zJ2dNpFx0=


### PR DESCRIPTION
Get build status notifications in our Slack channel. Only reports upon status change so should be extremely low volume so long as no-one breaks master.