### PR TITLE
Aggregate Root defaults correlation_id to uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Event#to_h` method. This returns a hash of the event attributes.
 - Added `Event#with` method. This provides a way to create a new event
   identical to the old event except for the provided changes.
+- `AggregateRoot` when apply event, if unprovided, sets `correlation_id`
+  to the event `uuid` when applying events.
 
 ## [0.13.0] - 2016-6-16
 ### Added

--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -43,8 +43,17 @@ module EventSourcery
 
     attr_reader :id
 
-    def apply_event(event_class, options = {})
-      event = event_class.new(**options.merge(aggregate_id: id))
+    def apply_event(event_class,
+                    uuid: SecureRandom.uuid,
+                    correlation_id: uuid,
+                    **event_attributes)
+      event = event_class.new(
+        **event_attributes.merge(
+          uuid: uuid,
+          correlation_id: correlation_id,
+          aggregate_id: id
+        )
+      )
       mutate_state_from(event)
       @changes << event
     end

--- a/spec/event_sourcery/aggregate_root_spec.rb
+++ b/spec/event_sourcery/aggregate_root_spec.rb
@@ -120,16 +120,14 @@ RSpec.describe EventSourcery::AggregateRoot do
       subject(:aggregate) do
         new_aggregate(aggregate_uuid) do
           def add_item(item)
-            apply_event ItemAdded, correlation_id: '4fccabfd-5e15-4e41-946a-9bf9421ff4f7
-'
+            apply_event ItemAdded, correlation_id: '4fccabfd-5e15-4e41-946a-9bf9421ff4f7'
           end
         end
       end
 
       it 'uses the provided correlation_id' do
         emitted_event = aggregate.changes.first
-        expect(emitted_event.correlation_id).to eq('4fccabfd-5e15-4e41-946a-9bf9421ff4f7
-')
+        expect(emitted_event.correlation_id).to eq('4fccabfd-5e15-4e41-946a-9bf9421ff4f7')
       end
     end
 

--- a/spec/event_sourcery/aggregate_root_spec.rb
+++ b/spec/event_sourcery/aggregate_root_spec.rb
@@ -116,6 +116,30 @@ RSpec.describe EventSourcery::AggregateRoot do
       expect(emitted_event.aggregate_id).to eq aggregate_uuid
     end
 
+    context 'when correlation_id is provided' do
+      subject(:aggregate) do
+        new_aggregate(aggregate_uuid) do
+          def add_item(item)
+            apply_event ItemAdded, correlation_id: '4fccabfd-5e15-4e41-946a-9bf9421ff4f7
+'
+          end
+        end
+      end
+
+      it 'uses the provided correlation_id' do
+        emitted_event = aggregate.changes.first
+        expect(emitted_event.correlation_id).to eq('4fccabfd-5e15-4e41-946a-9bf9421ff4f7
+')
+      end
+    end
+
+    context 'when correlation_id is not provided' do
+      it 'defaults the correlation_id to the event UUID' do
+        emitted_event = aggregate.changes.first
+        expect(emitted_event.correlation_id).to eq(emitted_event.uuid)
+      end
+    end
+
     context 'when changes are cleared' do
       it 'has no changes' do
         aggregate.clear_changes


### PR DESCRIPTION
I propose that if a `correlation_id` is not provided to an event applied on an aggregate the new event's `uuid` will be used in its place. I think this forms a sensible default. Individual systems remain free to provide a `correlation_id` based on web request/session id or the like.