### PR TITLE
Minor fixes to docs for better readability

### DIFF
--- a/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb
+++ b/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb
@@ -19,7 +19,7 @@ module EventSourcery
           @retry_interval = DEFAULT_RETRY_INVERAL
         end
 
-        # Will yeild the black and attempt to retry in an exponential backoff.
+        # Will yeild the block and attempt to retry in an exponential backoff.
         def with_error_handling
           yield
         rescue => error

--- a/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb
+++ b/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb
@@ -19,7 +19,7 @@ module EventSourcery
           @retry_interval = DEFAULT_RETRY_INVERAL
         end
 
-        # Will yeild the block and attempt to retry in an exponential backoff.
+        # Will yield the block and attempt to retry in an exponential backoff.
         def with_error_handling
           yield
         rescue => error

--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -18,7 +18,7 @@ module EventSourcery
       end
 
       module ProcessHandler
-        # Handler that will process the given event.
+        # Handler that processes the given event.
         #
         # @raise [EventProcessingError] error raised due to processing isssues
         # @raise [UnableToProcessEventError] raised if unable to process event type
@@ -50,14 +50,14 @@ module EventSourcery
         # @attr_reader event_handlers [Hash] Hash of handler blocks keyed by event
         attr_reader :processes_event_types, :event_handlers
 
-        # This will register the event types to process.
+        # Registers the event types to process.
         #
         # @param event_types a collection of event types to process
         def processes_events(*event_types)
           @processes_event_types = Array(@processes_event_types) | event_types.map(&:to_s)
         end
 
-        # Indicate that this class can process all event types. Note that you will need to call this method if you
+        # Indicate that this class can process all event types. Note that you need to call this method if you
         # intend to process all event types, without calling {ProcessHandler#process} for each event type.
         def processes_all_events
           define_singleton_method :processes? do |_|
@@ -77,7 +77,7 @@ module EventSourcery
         end
 
         # Set the name of the processor.
-        # If no name given then it will be the class name.
+        # Returns the class name if no name is given.
         #
         # @param name [String] the name of the processor to set
         def processor_name(name = nil)
@@ -100,7 +100,7 @@ module EventSourcery
         end
       end
 
-      # This calls the class method of processes_event_types
+      # Calls processes_event_types method on the instance class
       def processes_event_types
         self.class.processes_event_types
       end
@@ -122,12 +122,12 @@ module EventSourcery
         tracker.last_processed_event_id(processor_name)
       end
 
-      # This calls the class method of processor_name
+      # Calls processor_name method on the instance class
       def processor_name
         self.class.processor_name
       end
 
-      # This calls the class method of processes?
+      # Calls processes? method on the instance class
       def processes?(event_type)
         self.class.processes?(event_type)
       end

--- a/lib/event_sourcery/event_store/signal_handling_subscription_master.rb
+++ b/lib/event_sourcery/event_store/signal_handling_subscription_master.rb
@@ -1,6 +1,6 @@
 module EventSourcery
   module EventStore
-    # SubscriptionMaster manages shutdown signals and facilitate graceful shutdowns of subscriptions.
+    # Manages shutdown signals and facilitate graceful shutdowns of subscriptions.
     #
     # @see Subscription
     class SignalHandlingSubscriptionMaster
@@ -9,8 +9,8 @@ module EventSourcery
         setup_graceful_shutdown
       end
 
-      # If a shutdown has been requested through a `TERM` or `INT` signal, this will throw a `:stop` (generally) causing a Subscription
-      # to stop listening for events
+      # If a shutdown has been requested through a `TERM` or `INT` signal, this will throw a `:stop`
+      # (generally) causing a Subscription to stop listening for events.
       #
       # @see Subscription#start
       def shutdown_if_requested


### PR DESCRIPTION
Minor improvements to the public API docs to fixe one typo and make a few method descriptions a bit easier to understand.