### PR TITLE
Support event schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,28 +242,6 @@ To enforce validation, your event must supply two methods:
   should return a hash of errors detected during validation.
   
 The [dry-validation gem](https://github.com/dry-rb/dry-validation) may be used for event body validation.
-Here is an example of an event schema defined using [dry-types](https://github.com/dry-rb/dry-types):
-  
-```ruby
-  module Events
-    class SubscriptionCreated < EventSourcery::Event
-
-      attribute :subscription_uuid, Types::Coercible::String
-      attribute :plan_code, Types::Coercible::String
-      attribute :activated_at, Types::Form::Time
-      attribute :unit_amount_in_cents, Types::Form::Int
-      attribute :cancelled_at, Types::Form::Time
-
-      validations do
-        required(:subscription_uuid).filled(:uuid?)
-        required(:plan_code).filled(:str?)
-        required(:activated_at).filled(:time?)
-        required(:unit_amount_in_cents).filled(:int?)
-        required(:cancelled_at).maybe(:time?)
-      end
-    end
-  end
-```
 
 #### Reading Events
 

--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -124,8 +124,12 @@ module EventSourcery
 
     def apply_event(event_class, options = {})
       event = event_class.new(**options.merge(aggregate_id: id))
-      mutate_state_from(event)
-      @changes << event
+      if event.valid?
+        mutate_state_from(event)
+        @changes << event
+      else
+        raise(InvalidEventError, "#{event.class} not valid: #{event.validation_errors.values.join(', ')}")
+      end
     end
 
     def mutate_state_from(event)

--- a/lib/event_sourcery/errors.rb
+++ b/lib/event_sourcery/errors.rb
@@ -4,6 +4,7 @@ module EventSourcery
   UnableToProcessEventError = Class.new(Error)
   ConcurrencyError = Class.new(Error)
   AtomicWriteToMultipleAggregatesNotSupported = Class.new(Error)
+  InvalidEventError = Class.new(Error)
 
   class EventProcessingError < Error
     attr_reader :event

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -124,5 +124,10 @@ module EventSourcery
         causation_id:   causation_id,
       }
     end
+
+  #   Allow Event Validation with backwards compatibility for events that do not implement validation
+    def valid?
+      true
+    end
   end
 end


### PR DESCRIPTION
My team is working on an Event Sourcery app. We want to introduce event schema validation because:
- Event schemas document the intended structure of events and allow us to trace their history
- With a little bit of metaprogramming we can replace event body hash digging with attributes on events, making our code more readable
- Schema validation ensures all events have the intended format before being saved to the event store.
- Schema validation helps ensure that specs don't make faulty assumptions when creating test inputs. 

Other Envato apps have enforced validation of their event schemas by introducing parallel methods to `apply_event` and `emit_event` named `validate_and_apply_event` and `validate_and_emit_event`. I believe it would be better for schema validation to be directly supported by Event Sourcery rather than for each Event Sourcery app to implement it independently.

This PR adds that support. Note that event schema validation is entirely optional for apps; I have introduced a trivial `#valid?` method on `EventSourcery::Event` to ensure this change is backwards compatible.

Our app uses [dry-validation](https://github.com/dry-rb/dry-validation) for defining and enforcing the schemas, but that particular mechanism is not enforced here. It is only necessary for events to understand `#valid?` and provide a hash via `#validation_errors`

[An additional change](https://github.com/envato/event_sourcery-postgres/pull/36) is required for `event_sourcery-postgres`. They should be released together.