### PR TITLE
Expand the In Memory event store to be able to run a real (example) app.

### DIFF
--- a/lib/event_sourcery.rb
+++ b/lib/event_sourcery.rb
@@ -30,6 +30,7 @@ require 'event_sourcery/repository'
 require 'event_sourcery/memory/tracker'
 require 'event_sourcery/memory/event_store'
 require 'event_sourcery/memory/config'
+require 'event_sourcery/memory/projector'
 
 module EventSourcery
   # Configure EventSourcery

--- a/lib/event_sourcery.rb
+++ b/lib/event_sourcery.rb
@@ -29,6 +29,7 @@ require 'event_sourcery/aggregate_root'
 require 'event_sourcery/repository'
 require 'event_sourcery/memory/tracker'
 require 'event_sourcery/memory/event_store'
+require 'event_sourcery/memory/config'
 
 module EventSourcery
   # Configure EventSourcery

--- a/lib/event_sourcery/memory/config.rb
+++ b/lib/event_sourcery/memory/config.rb
@@ -1,0 +1,36 @@
+module EventSourcery
+  module Memory
+    class Config
+      attr_accessor :event_tracker,
+                    :event_store,
+                    :event_source,
+                    :event_sink
+
+      def initialize
+        @event_tracker = Memory::Tracker.new
+      end
+
+      def event_store
+        @event_store ||= EventStore.new
+      end
+
+      def event_source
+        @event_source ||= ::EventSourcery::EventStore::EventSource.new(event_store)
+      end
+
+      def event_sink
+        @event_sink ||= ::EventSourcery::EventStore::EventSink.new(event_store)
+      end
+
+    end
+
+    def self.configure
+      yield config
+    end
+
+    def self.config
+      @config ||= Config.new
+    end
+
+  end
+end

--- a/lib/event_sourcery/memory/event_store.rb
+++ b/lib/event_sourcery/memory/event_store.rb
@@ -43,11 +43,7 @@ module EventSourcery
           )
         end
 
-        events.each do |event|
-          @listeners.each do |listener|
-            listener.process(event)
-          end
-        end
+        project_events(events)
 
         true
       end
@@ -123,6 +119,16 @@ module EventSourcery
       # @param listener A single istener or an array of listeners
       def add_listeners(listeners)
         @listeners.concat(Array(listeners))
+      end
+
+      private
+
+      def project_events(events)
+        events.each do |event|
+          @listeners.each do |listener|
+            listener.process(event)
+          end
+        end
       end
     end
   end

--- a/lib/event_sourcery/memory/projector.rb
+++ b/lib/event_sourcery/memory/projector.rb
@@ -5,6 +5,11 @@ module EventSourcery
       def self.included(base)
         base.include(EventSourcery::EventProcessing::EventStreamProcessor)
         base.include(InstanceMethods)
+        base.class_eval do
+          class << self
+            alias_method :projector_name, :processor_name
+          end
+        end
       end
 
       module InstanceMethods

--- a/lib/event_sourcery/memory/projector.rb
+++ b/lib/event_sourcery/memory/projector.rb
@@ -9,6 +9,7 @@ module EventSourcery
           alias_method :project, :process
           class << self
             alias_method :project, :process
+            alias_method :projects_events, :processes_events
             alias_method :projector_name, :processor_name
           end
         end

--- a/lib/event_sourcery/memory/projector.rb
+++ b/lib/event_sourcery/memory/projector.rb
@@ -6,7 +6,9 @@ module EventSourcery
         base.include(EventSourcery::EventProcessing::EventStreamProcessor)
         base.include(InstanceMethods)
         base.class_eval do
+          alias_method :project, :process
           class << self
+            alias_method :project, :process
             alias_method :projector_name, :processor_name
           end
         end

--- a/lib/event_sourcery/memory/projector.rb
+++ b/lib/event_sourcery/memory/projector.rb
@@ -1,0 +1,17 @@
+module EventSourcery
+  module Memory
+    module Projector
+
+      def self.included(base)
+        base.include(EventSourcery::EventProcessing::EventStreamProcessor)
+        base.include(InstanceMethods)
+      end
+
+      module InstanceMethods
+        def initialize(tracker: EventSourcery::Memory.config.event_tracker)
+          @tracker = tracker
+        end
+      end
+    end
+  end
+end

--- a/spec/event_sourcery/memory/config_spec.rb
+++ b/spec/event_sourcery/memory/config_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe EventSourcery::Memory::Config do
+  subject(:config) { described_class.new }
+
+  context 'when reading the event_store' do
+    it 'returns a EventSourcery::Memory::EventStore' do
+      expect(config.event_store).to be_instance_of(EventSourcery::Memory::EventStore)
+    end
+
+    it 'returns a EventSourcery::EventStore::EventSource' do
+      expect(config.event_source).to be_instance_of(EventSourcery::EventStore::EventSource)
+    end
+
+    it 'returns a EventSourcery::EventStore::EventSink' do
+      expect(config.event_sink).to be_instance_of(EventSourcery::EventStore::EventSink)
+    end
+
+    it 'returns a EventSourcery::Memory::Tracker' do
+      expect(config.event_tracker).to be_instance_of(EventSourcery::Memory::Tracker)
+    end
+
+    context 'and an event_store is set' do
+      let(:event_store) { double(:event_store) }
+      before do
+        config.event_store = event_store
+      end
+
+      it 'returns the event_store' do
+        expect(config.event_store).to eq(event_store)
+      end
+    end
+
+  end
+end

--- a/spec/event_sourcery/memory/event_store_spec.rb
+++ b/spec/event_sourcery/memory/event_store_spec.rb
@@ -1,12 +1,25 @@
 RSpec.describe EventSourcery::Memory::EventStore do
   let(:supports_versions) { false }
+  let(:event) { EventSourcery::Event.new(type: 'blah', aggregate_id: SecureRandom.uuid, body: {}) }
   subject(:event_store) { described_class.new([], event_builder: EventSourcery.config.event_builder) }
 
   include_examples 'an event store'
 
   it 'ignores an expected_version param' do
     expect {
-      event_store.sink(EventSourcery::Event.new(type: 'blah', aggregate_id: SecureRandom.uuid, body: {}))
+      event_store.sink(event)
     }.to_not raise_error
+  end
+
+  it 'passes events to listeners' do
+    listener = Class.new do
+      def process(event)
+        @processed_event = event
+      end
+      attr_reader :processed_event
+    end.new()
+    event_store.add_listeners(listener)
+    event_store.sink(event)
+    expect(listener.processed_event).to eq(event)
   end
 end

--- a/spec/event_sourcery/memory/projector_spec.rb
+++ b/spec/event_sourcery/memory/projector_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe EventSourcery::Memory::Projector do
   let(:projector_class) do
     Class.new do
       include EventSourcery::Memory::Projector
+      processor_name 'test_processor'
     end
   end
 
@@ -24,6 +25,12 @@ RSpec.describe EventSourcery::Memory::Projector do
 
     it 'uses the inferred event tracker by default' do
       expect(projector.instance_variable_get('@tracker')).to eq event_tracker
+    end
+  end
+
+  describe '.projector_name' do
+    it 'delegates to processor_name' do
+      expect(projector_class.projector_name).to eq 'test_processor'
     end
   end
 

--- a/spec/event_sourcery/memory/projector_spec.rb
+++ b/spec/event_sourcery/memory/projector_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe EventSourcery::Memory::Projector do
+  let(:projector_class) do
+    Class.new do
+      include EventSourcery::Memory::Projector
+    end
+  end
+
+  let(:tracker) { EventSourcery::Memory::Tracker.new }
+
+  subject(:projector) do
+    projector_class.new(
+      tracker: tracker
+    )
+  end
+
+  describe '.new' do
+    let(:event_tracker) { double }
+
+    before do
+      allow(EventSourcery::Memory::Tracker).to receive(:new).and_return(event_tracker)
+    end
+
+    subject(:projector) { projector_class.new }
+
+    it 'uses the inferred event tracker by default' do
+      expect(projector.instance_variable_get('@tracker')).to eq event_tracker
+    end
+  end
+
+end

--- a/spec/event_sourcery/memory/projector_spec.rb
+++ b/spec/event_sourcery/memory/projector_spec.rb
@@ -76,4 +76,14 @@ RSpec.describe EventSourcery::Memory::Projector do
     end
   end
 
+  describe '.projects_events' do
+    it 'is aliased to processes_events' do
+      projector_class = Class.new do
+        include EventSourcery::Memory::Projector
+        projects_events :item_added
+      end
+      expect(projector_class.processes?(:item_added)).to eq true
+    end
+  end
+
 end


### PR DESCRIPTION
# Goal
The goal of this PR is to get the In Memory Event Store to a state where it can be used in running example applications.  It has some limitations but it can be used to demonstrate concepts without any dependencies.  

The approach was to, as far as possible, follow the Postgres API so that the example store could easily be swapped for the real thing.

# Config
Added an in-memory config class to be similar to the Postgres Config class.  This allows search/replace of Postgres to Memory in `environment.rb` to switch between Postgres & Memory (plus deleting the database setup bits).

# Projector
Added an in-memory projector that uses the in-memory config and follows the same API as the Postgres projector.  Also adds a no-parameter constructor so that Postgres can easily be replaced with in-memory config (and the other way around).

# Listeners 
Added listeners to the in-memory store so that the event processors can be executed as part of the execution.

# Limitations
*  This requires all projectors to be executing in the same process as the in-memory store. 
*  Event processors are executed synchronously