### PR TITLE
Validate events on sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,25 @@ Naturally, it provides the ability to store events. The event store is append-on
 
 When used in this fashion the event store can be thought of as an event sink.
 
+##### Event Validation
+
+Events may be given defined schemas which are validated before the event is saved in the event store.
+
+There are several reasons why you may choose to enforce schemas on your events:
+
+* Event schemas document the intended structure of events and allow you to trace their history via source control
+* Schema validation ensures all events have the intended format before being saved to the event store. This is particularly important because events are immutable.
+* Schema validation ensures that specs don't make faulty assumptions when creating test inputs.
+* Schemas may be used to supply the event with attributes, eg `event.plan_code` rather than `event.body.fetch('plan_code')`. This improves the readability of your code.
+
+To enforce validation, your event must supply two methods:
+* `#valid?`  
+  should return true if the event body is valid, false otherwise.
+* `#validation_errors`  
+  should return a hash of errors detected during validation.
+  
+The [dry-validation gem](https://github.com/dry-rb/dry-validation) may be used for event body validation.
+
 #### Reading Events
 
 The `EventStore` also allows clients to read events. Clients can poll the store for events of specific types after a specific event ID. They can also subscribe to the event store to be notified when new events are added to the event store that match the above criteria.

--- a/lib/event_sourcery/errors.rb
+++ b/lib/event_sourcery/errors.rb
@@ -4,6 +4,7 @@ module EventSourcery
   UnableToProcessEventError = Class.new(Error)
   ConcurrencyError = Class.new(Error)
   AtomicWriteToMultipleAggregatesNotSupported = Class.new(Error)
+  InvalidEventError = Class.new(Error)
 
   class EventProcessingError < Error
     attr_reader :event

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -124,5 +124,10 @@ module EventSourcery
         causation_id:   causation_id,
       }
     end
+
+    #   Allow Event Validation with backwards compatibility for events that do not implement validation
+    def valid?
+      true
+    end
   end
 end

--- a/lib/event_sourcery/event_store/event_sink.rb
+++ b/lib/event_sourcery/event_store/event_sink.rb
@@ -7,8 +7,13 @@ module EventSourcery
         @event_store = event_store
       end
 
-      extend Forwardable
-      def_delegators :event_store, :sink
+      def sink(event_or_events, expected_version: nil)
+        events = Array(event_or_events)
+        events.each do |event|
+          raise(InvalidEventError, "#{event.class} not valid: #{event.validation_errors.values.join(', ')}") unless event.valid?
+        end
+        event_store.sink(events, expected_version: expected_version)
+      end
 
       private
 

--- a/spec/event_sourcery/event_store/event_sink_spec.rb
+++ b/spec/event_sourcery/event_store/event_sink_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe EventSourcery::EventStore::EventSink do
+  let(:event_store) { double(:event_store, sink: nil) }
+  subject(:event_sink) { described_class.new(event_store) }
+
+  let(:valid_event_1) { double(EventSourcery::Event, valid?: true) }
+  let(:valid_event_2) { double(EventSourcery::Event, valid?: true) }
+  let(:invalid_event) { double(EventSourcery::Event, valid?: false, validation_errors: {one: 'this event is invalid'}) }
+
+  describe '#sink' do
+    context 'when the events are in an array' do
+      context 'and all events are valid' do
+        let(:events) { [valid_event_1, valid_event_2] }
+
+        it 'validates all events in the array' do
+          event_sink.sink(events, expected_version: 3)
+          expect(valid_event_1).to have_received(:valid?)
+          expect(valid_event_2).to have_received(:valid?)
+        end
+
+        it 'passes the array and the expected version to the event store' do
+          event_sink.sink(events, expected_version: 3)
+          expect(event_store).to have_received(:sink).with(events, expected_version: 3)
+        end
+      end
+
+      context 'and the last event is invalid' do
+        let(:events) { [valid_event_1, invalid_event] }
+
+        it 'validates all events in the array' do
+          begin
+          event_sink.sink(events)
+          rescue
+          end
+          expect(valid_event_1).to have_received(:valid?)
+          expect(invalid_event).to have_received(:valid?)
+        end
+
+        it 'does not pass the array to the event store' do
+          begin
+            event_sink.sink(events)
+          rescue
+          end
+          expect(event_store).not_to have_received(:sink)
+        end
+
+        it 'raises an InvalidEventError' do
+          expect{ event_sink.sink(events) }.to raise_error EventSourcery::InvalidEventError, /this event is invalid/
+        end
+      end
+    end
+
+    context 'when the event is passed in by itself' do
+      context 'and the event is valid' do
+        it 'validates the event' do
+          event_sink.sink(valid_event_1)
+          expect(valid_event_1).to have_received(:valid?)
+        end
+
+        it 'wraps the event in an array and passes it to the event store' do
+          event_sink.sink(valid_event_1)
+          expect(event_store).to have_received(:sink).with([valid_event_1], expected_version: nil)
+        end
+      end
+    end
+
+    context 'and the event is invalid' do
+      it 'validates the event' do
+        begin
+          event_sink.sink(invalid_event)
+        rescue
+        end
+        expect(invalid_event).to have_received(:valid?)
+      end
+
+      it 'does not pass the event to the event store' do
+        begin
+          event_sink.sink(invalid_event)
+        rescue
+        end
+        expect(event_store).not_to have_received(:sink)
+      end
+
+      it 'raises an InvalidEvent exception' do
+        expect{ event_sink.sink(invalid_event) }.to raise_error EventSourcery::InvalidEventError, /this event is invalid/
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is a replacement for https://github.com/envato/event_sourcery/pull/174 and https://github.com/envato/event_sourcery-postgres/pull/36. 

See the discussion there around best time to validate events.

Here I'm validating on `sink` rather than on `apply_event` and `emit_event`.

Is there a risk here of action being taken on receiving or creating an invalid event, before that event is stored? Do we need to validate in more than one place? What do you think?