### PR TITLE
Improve event processing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added in the first version of the yard documentation.
 
+### Changed
+- Improved EventProcessingError messages
+
 ## [0.14.0] - 2016-6-21
 ### Added
 - Added `Event#to_h` method. This returns a hash of the event attributes.

--- a/lib/event_sourcery/errors.rb
+++ b/lib/event_sourcery/errors.rb
@@ -6,14 +6,19 @@ module EventSourcery
   AtomicWriteToMultipleAggregatesNotSupported = Class.new(Error)
 
   class EventProcessingError < Error
-    attr_reader :event
+    attr_reader :event, :processor
 
-    def initialize(event)
+    def initialize(event:, processor:)
       @event = event
+      @processor = processor
     end
 
     def message
-      cause.message if cause
+      parts = []
+      parts << "#<#{processor.class} @@processor_name=#{processor.processor_name.inspect}>"
+      parts << "#<#{event.class} @id=#{event.id.inspect}, @uuid=#{event.uuid.inspect}, @type=#{event.type.inspect}>"
+      parts << "#<#{cause.class}: #{cause.message}>"
+      parts.join("\n") + "\n"
     end
   end
 end

--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -40,7 +40,7 @@ module EventSourcery
           end
           @_event = nil
         rescue
-          raise EventProcessingError.new(event)
+          raise EventProcessingError.new(event: event, processor: self)
         end
       end
 

--- a/spec/event_sourcery/event_processing/error_handlers/constant_retry_spec.rb
+++ b/spec/event_sourcery/event_processing/error_handlers/constant_retry_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::ConstantRetry do
     end
 
     context 'when the raised errors are EventProcessingError' do
-      let(:error) { EventSourcery::EventProcessingError.new(event: event) }
+      let(:event_processor) { double :event_processor }
+      let(:error) { EventSourcery::EventProcessingError.new(event: event, processor: event_processor) }
       before do
         allow(error).to receive(:cause).and_return(cause)
         with_error_handling

--- a/spec/event_sourcery/event_processing/error_handlers/exponential_backoff_retry_spec.rb
+++ b/spec/event_sourcery/event_processing/error_handlers/exponential_backoff_retry_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::ExponentialBackoff
   end
 
   describe '#with_error_handling' do
+    let(:event_processor) { double :event_processor }
     let(:cause) { double(to_s: 'OriginalError', backtrace: ['back', 'trace']) }
     let(:event) { double(uuid: SecureRandom.uuid) }
     let(:number_of_errors_to_raise) { 3 }
@@ -54,7 +55,7 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::ExponentialBackoff
         with_error_handling
       end
 
-      let(:error) { EventSourcery::EventProcessingError.new(event) }
+      let(:error) { EventSourcery::EventProcessingError.new(event: event, processor: event_processor) }
 
       it 'logs the original error' do
         expect(logger).to have_received(:error).thrice.with("Processor #{processor_name} died with OriginalError.\nback\ntrace")
@@ -84,9 +85,9 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::ExponentialBackoff
         with_error_handling
       end
 
-      let(:error_for_event) { EventSourcery::EventProcessingError.new(event) }
+      let(:error_for_event) { EventSourcery::EventProcessingError.new(event: event, processor: event_processor) }
       let(:another_event) { double(uuid: SecureRandom.uuid) }
-      let(:error_for_another_event) { EventSourcery::EventProcessingError.new(another_event) }
+      let(:error_for_another_event) { EventSourcery::EventProcessingError.new(event: another_event, processor: event_processor) }
       subject(:with_error_handling) do
         @count = 0
         error_handler.with_error_handling do

--- a/spec/event_sourcery/event_processing/error_handlers/no_retry_spec.rb
+++ b/spec/event_sourcery/event_processing/error_handlers/no_retry_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe EventSourcery::EventProcessing::ErrorHandlers::NoRetry do
     end
 
     context 'when the raised errors are EventProcessingError' do
-      let(:error) { EventSourcery::EventProcessingError.new(event) }
+      let(:event_processor) { double :event_processor }
+      let(:error) { EventSourcery::EventProcessingError.new(event: event, processor: event_processor) }
 
       it 'logs the original error' do
         expect(logger).to have_received(:error).once.with("Processor #{processor_name} died with OriginalError.\nback\ntrace")

--- a/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
@@ -180,17 +180,8 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
     end
 
     context 'when using specific event handlers' do
-      def new_esp(&block)
-        Class.new do
-          include EventSourcery::EventProcessing::EventStreamProcessor
-          processor_name 'my_processor'
-
-          class_eval(&block)
-        end.new(tracker: tracker)
-      end
-
       subject(:event_processor) {
-        new_esp do
+        new_event_processor do
           process ItemAdded do |event|
             @added_event = event
           end
@@ -218,7 +209,7 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
 
       context 'processing multiple events in handlers' do
         let(:event_processor) {
-          new_esp do
+          new_event_processor do
             process ItemAdded do |event|
               @added_event = event
             end

--- a/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
@@ -241,13 +241,16 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
       end
 
       context 'processing events and raise error' do
-        let(:event_processor) {
-          new_esp do
-            process ItemAdded do |event|
-              raise 'Something is wrong'
-            end
+        class FooProcessor
+          include EventSourcery::EventProcessing::EventStreamProcessor
+          processor_name 'foo_processor'
+
+          process ItemAdded do |event|
+            raise 'Something is wrong'
           end
-        }
+        end
+
+        let(:event_processor) { FooProcessor.new(tracker: tracker) }
 
         it 'wraps raised exception with EventProcessingError' do
           expect {
@@ -255,7 +258,11 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
           }.to raise_error { |error|
             expect(error).to be_a(EventSourcery::EventProcessingError)
             expect(error.event).to eq item_added_event
-            expect(error.cause.message).to eq 'Something is wrong'
+            expect(error.message).to eq <<-EOF.gsub(/^ {14}/, '')
+              #<FooProcessor @@processor_name="foo_processor">
+              #<ItemAdded @id=nil, @uuid="#{item_added_event.uuid}", @type="item_added">
+              #<RuntimeError: Something is wrong>
+            EOF
           }
         end
       end


### PR DESCRIPTION
It can be difficult to tell where failures are coming from in some cases. This change makes it clear by including the processor name and event content.

Example of the improved error:

```
Failures:

  1) item GET /item/:item_id with events returns an item
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: processor.process(event)

          EventSourcery::EventProcessingError:
            #<Shoebox::Queries::Item::Projector @@processor_name=:item>
            #<EventSourcery::Event @id=86, @uuid="11950d74-ae2d-4df7-833c-e9372d7675a1", @type="asset_provided">
            #<RuntimeError: the roof>
          # /Users/odin/Dev/github/event_sourcery/event_sourcery/lib/event_sourcery/event_processing/event_stream_processor.rb:43:in `rescue in process'
          # /Users/odin/Dev/github/event_sourcery/event_sourcery/lib/event_sourcery/event_processing/event_stream_processor.rb:28:in `process'
          # ./spec/support/publish_event_helpers.rb:20:in `block (2 levels) in process_events_with_processors'
```
