### PR TITLE
Log non-standard errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed typo in constant name `EventSourcery::EventProcessing::ErrorHandlers::ConstantRetry::DEFAULT_RETRY_INTERVAL`
 - Fixed typo in constant name `EventSourcery::EventProcessing::ErrorHandlers::ExponentialBackoffRetry::DEFAULT_RETRY_INTERVAL`
 - Fixed typo in constant name `EventSourcery::EventProcessing::ErrorHandlers::ExponentialBackoffRetry::MAX_RETRY_INTERVAL`
+- Errors of type `Exception` are now logged before being allowed to propagate.
 
 ## [0.14.0] - 2016-6-21
 ### Added

--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -18,6 +18,9 @@ module EventSourcery
           subscribe_to_event_stream
           EventSourcery.logger.info("Stopping #{@event_processor.processor_name}")
         end
+      rescue Exception => e
+        EventSourcery.logger.error(e)
+        raise e
       end
 
       private

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -15,41 +15,58 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
 
   describe '#start' do
     subject(:start) { esp_process.start }
-    let(:error) { StandardError.new }
     let(:logger) { spy(Logger) }
 
     before do
       allow(EventSourcery.config.error_handler_class).to receive(:new)
         .with(processor_name: processor_name).and_return(error_handler)
       allow(EventSourcery).to receive(:logger).and_return(logger)
-      allow(error_handler).to receive(:with_error_handling).and_yield
-      allow(logger).to receive(:info)
-      allow(Process).to receive(:setproctitle)
-
-      allow(esp).to receive(:subscribe_to)
-
-      start
     end
 
+    context 'when no error is raised' do
+      before do
+        allow(error_handler).to receive(:with_error_handling).and_yield
+        allow(logger).to receive(:info)
+        allow(Process).to receive(:setproctitle)
 
-    it 'names process with ESP name' do
-      expect(Process).to have_received(:setproctitle).with('SomeApp::Reactors::SomeReactor')
+        allow(esp).to receive(:subscribe_to)
+
+        start
+      end
+
+      it 'names process with ESP name' do
+        expect(Process).to have_received(:setproctitle).with('SomeApp::Reactors::SomeReactor')
+      end
+
+      it 'wraps event processing inside error handler' do
+        expect(error_handler).to have_received(:with_error_handling)
+      end
+
+      it 'logs info when starting ESP' do
+        expect(logger).to have_received(:info).with("Starting #{processor_name}")
+      end
+
+      it 'subscribes event processor to event store' do
+        expect(esp).to have_received(:subscribe_to)
+      end
+
+      it 'logs info when stopping ESP' do
+        expect(logger).to have_received(:info).with("Stopping #{processor_name}")
+      end
     end
 
-    it 'wraps event processing inside error handler' do
-      expect(error_handler).to have_received(:with_error_handling)
-    end
+    context 'when the raised error is Exception' do
+      let(:error) { Exception.new('Non-standard error') }
 
-    it 'logs info when starting ESP' do
-      expect(logger).to have_received(:info).with("Starting #{processor_name}")
-    end
+      before do
+        allow(error_handler).to receive(:with_error_handling).and_raise(error)
+        allow(logger).to receive(:error).with(error)
+      end
 
-    it 'subscribes event processor to event store' do
-      expect(esp).to have_received(:subscribe_to)
-    end
-
-    it 'logs info when stopping ESP' do
-      expect(logger).to have_received(:info).with("Stopping #{processor_name}")
+      it 'logs and re-raises the error' do
+        expect { start }.to raise_error(error)
+        expect(logger).to have_received(:error).with(error)
+      end
     end
   end
 end


### PR DESCRIPTION
There is currently no visibility into non-standard errors raised by processors, making debugging these types of errors very difficult.

This change logs these errors before propagating them.