### PR TITLE
Resolve Ruby warnings

### DIFF
--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -37,7 +37,7 @@ module EventSourcery
       @on_event_processor_error = proc { |exception, processor_name|
         # app specific custom logic ie. report to an error reporting service like Rollbar.
       }
-      @event_store = nil
+      @event_builder = nil
       @event_type_serializer = EventStore::EventTypeSerializers::Underscored.new
       @error_handler_class = EventProcessing::ErrorHandlers::ConstantRetry
     end

--- a/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb
+++ b/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb
@@ -17,6 +17,7 @@ module EventSourcery
         def initialize(processor_name:)
           @processor_name = processor_name
           @retry_interval = DEFAULT_RETRY_INTERVAL
+          @error_event_uuid = nil
         end
 
         # Will yield the block and attempt to retry in an exponential backoff.

--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -38,7 +38,7 @@ module EventSourcery
 
       module ClassMethods
 
-        # @attr_reader processes_event_types [Array] Process Event Types
+        # @attr_reader processes_event_types [Set] Process Event Types
         # @attr_reader event_handlers [Hash] Hash of handler blocks keyed by event
         # @attr_reader all_event_handler [Proc] An event handler
         attr_reader :processes_event_types, :event_handlers, :all_event_handler
@@ -79,8 +79,9 @@ module EventSourcery
               @all_event_handler = block
             end
           else
+            @processes_event_types ||= Set.new
             event_classes.each do |event_class|
-              @processes_event_types = Array(@processes_event_types) | [event_class.type]
+              @processes_event_types << event_class.type
               @event_handlers[event_class.type] << block
             end
           end

--- a/lib/event_sourcery/memory/config.rb
+++ b/lib/event_sourcery/memory/config.rb
@@ -1,10 +1,8 @@
 module EventSourcery
   module Memory
     class Config
-      attr_accessor :event_tracker,
-                    :event_store,
-                    :event_source,
-                    :event_sink
+      attr_accessor :event_tracker
+      attr_writer :event_store, :event_source, :event_sink
 
       def initialize
         @event_tracker = Memory::Tracker.new

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
 
       context 'given the process does not terminate until killed' do
         before do
+          @stop_process = false
           allow(Process).to receive(:wait2) { [pid, failure_status] if @stop_process }
           allow(Process).to receive(:kill).with(:KILL, pid) { @stop_process = true}
         end

--- a/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
       end
 
       it 'returns the events in processed event types' do
-        expect(event_processor.class.processes_event_types).to eq(['item_added', 'item_removed'])
+        expect(event_processor.processes_event_types).to contain_exactly('item_added', 'item_removed')
       end
 
       context 'processing multiple events in handlers' do


### PR DESCRIPTION
Ruby produces several warnings while running our test suite:
https://travis-ci.org/envato/event_sourcery/jobs/322691568

This change set resolves these warnings:

```
event_sourcery/lib/event_sourcery/memory/config.rb:13: warning: method redefined; discarding old event_store
event_sourcery/lib/event_sourcery/memory/config.rb:17: warning: method redefined; discarding old event_source
event_sourcery/lib/event_sourcery/memory/config.rb:21: warning: method redefined; discarding old event_sink
event_sourcery/spec/event_sourcery/event_processing/esp_runner_spec.rb:104: warning: instance variable @stop_process not initialized
event_sourcery/lib/event_sourcery/event_processing/error_handlers/exponential_backoff_retry.rb:36: warning: instance variable @error_event_uuid not initialized
event_sourcery/lib/event_sourcery/config.rb:57: warning: instance variable @event_builder not initialized
event_sourcery/lib/event_sourcery/event_processing/event_stream_processor.rb:83: warning: instance variable @processes_event_types not initialized
```
