### PR TITLE
 Allow changing the event class using Event#with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Allow changing the event class using Event#with
 
 ## [0.16.0] - 2018-01-02
 ### Added

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -111,6 +111,10 @@ module EventSourcery
     #     new_event.type # => "item_removed"
     #     new_event.class # => ItemRemoved
     def with(event_class: self.class, **attributes)
+      if self.class != Event && !attributes[:type].nil? && attributes[:type] != type
+        raise Error, 'When using typed events change the type by changing the event class.'
+      end
+
       event_class.new(**to_h.merge!(attributes))
     end
 

--- a/lib/event_sourcery/event.rb
+++ b/lib/event_sourcery/event.rb
@@ -104,8 +104,14 @@ module EventSourcery
     #     # Of course, with can accept any number of event attributes:
     #
     #     new_event = old_event.with(id: 42, version: 77, body: { 'attr' => 'value' })
-    def with(**attributes)
-      self.class.new(**to_h.merge!(attributes))
+    #
+    #     # When using typed events you can also override the event class:
+    #
+    #     new_event = old_event.with(event_class: ItemRemoved)
+    #     new_event.type # => "item_removed"
+    #     new_event.class # => ItemRemoved
+    def with(event_class: self.class, **attributes)
+      event_class.new(**to_h.merge!(attributes))
     end
 
     # returns a hash of the event attributes

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -163,6 +163,13 @@ RSpec.describe EventSourcery::Event do
         expect(original_event.send(attribute)).to(eq(value))
       end
     end
+
+    it 'allows changing the event class' do
+      new_event = original_event.with(event_class: ItemAdded)
+
+      expect(new_event).to be_a ItemAdded
+      expect(new_event.type).to eq 'item_added'
+    end
   end
 
   describe '#to_h' do

--- a/spec/event_sourcery/event_spec.rb
+++ b/spec/event_sourcery/event_spec.rb
@@ -170,6 +170,29 @@ RSpec.describe EventSourcery::Event do
       expect(new_event).to be_a ItemAdded
       expect(new_event.type).to eq 'item_added'
     end
+
+    it 'allows changing the event class of a typed event' do
+      original_event = ItemRemoved.new
+      new_event = original_event.with(event_class: ItemAdded)
+
+      expect(new_event).to be_a ItemAdded
+      expect(new_event.type).to eq 'item_added'
+    end
+
+    it 'allows changing the event type' do
+      original_event = EventSourcery::Event.new(type: 'item_removed')
+
+      new_event = original_event.with(type: 'item_added')
+      expect(new_event.type).to eq 'item_added'
+    end
+
+    it 'errors when attempting to change the type of a typed event' do
+      original_event = ItemRemoved.new(type: 'item_removed')
+
+      expect {
+        original_event.with(type: 'item_added')
+      }.to raise_error EventSourcery::Error, 'When using typed events change the type by changing the event class.'
+    end
   end
 
   describe '#to_h' do


### PR DESCRIPTION
With typed events you can't change the event type, let's allow changing the event class.


```ruby
old_event = ItemAdded.new

new_event = old_event.with(event_class: ItemRemoved)
new_event.type # => "item_removed"
new_event.class # => ItemRemoved
```