### PR TITLE
Revert back to Array for processes_event_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.16.1] - 2018-01-17
+- Fixed bug with Sequel gem expecting processes_event_types to be an Array
+
 ## [0.16.0] - 2018-01-02
 ### Added
 - Added additional logging for retries to the ExponentialBackoffRetry error handler

--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -38,7 +38,7 @@ module EventSourcery
 
       module ClassMethods
 
-        # @attr_reader processes_event_types [Set] Process Event Types
+        # @attr_reader processes_event_types [Array] Process Event Types
         # @attr_reader event_handlers [Hash] Hash of handler blocks keyed by event
         # @attr_reader all_event_handler [Proc] An event handler
         attr_reader :processes_event_types, :event_handlers, :all_event_handler
@@ -79,7 +79,7 @@ module EventSourcery
               @all_event_handler = block
             end
           else
-            @processes_event_types ||= Set.new
+            @processes_event_types ||= []
             event_classes.each do |event_class|
               @processes_event_types << event_class.type
               @event_handlers[event_class.type] << block

--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,4 +1,4 @@
 module EventSourcery
   # Defines the version
-  VERSION = '0.16.0'.freeze
+  VERSION = '0.16.1'.freeze
 end


### PR DESCRIPTION
In a previous PR we changed `processes_event_types` to a Set as a byproduct of refactoring code 
to prevent a ruby warning. Turns out that Sequel really wants this as an Array.

Previous Change: https://github.com/envato/event_sourcery/commit/3871b38ef4e6ffc4a6a430b8e66d2002291c253d

The result was every EventProcessor was dying because the Sequel gem was unable to convert a Set as a SQL Literal when it tried to subscribe to the event store for changes. 

So this just reverts back to using an Array.  