### PR TITLE
Allow specifying a subscription batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+- Allow specifying a subscription batch size
+
 ## [0.17.0] - 2018-03-22
 ### Added
 - Allow changing the event class using Event#with

--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -29,6 +29,9 @@ module EventSourcery
                 :event_body_serializer,
                 :event_builder
 
+    # @return Fixnum
+    attr_accessor :subscription_batch_size
+
     # @api private
     def initialize
       @on_unknown_event = proc { |event, aggregate|
@@ -40,6 +43,7 @@ module EventSourcery
       @event_builder = nil
       @event_type_serializer = EventStore::EventTypeSerializers::Underscored.new
       @error_handler_class = EventProcessing::ErrorHandlers::ConstantRetry
+      @subscription_batch_size = 1000
     end
 
     # Logger instance used by EventSourcery.

--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -29,7 +29,7 @@ module EventSourcery
                 :event_body_serializer,
                 :event_builder
 
-    # @return Fixnum
+    # @return Integer
     attr_accessor :subscription_batch_size
 
     # @api private

--- a/spec/event_sourcery/event_store/subscription_spec.rb
+++ b/spec/event_sourcery/event_store/subscription_spec.rb
@@ -70,4 +70,24 @@ RSpec.describe EventSourcery::EventStore::Subscription do
       expect(@event_batches.last.map(&:type)).to eq ['item_added']
     end
   end
+
+  it 'uses a default batch size' do
+    expect(event_store).to receive(:get_next_from).with(1, event_types: nil, limit: 1000).and_return []
+
+    subscription.start
+  end
+
+  it 'allows specifying a batch size' do
+    subscription = described_class.new(event_store: event_store,
+                                       poll_waiter: waiter,
+                                       event_types: event_types,
+                                       from_event_id: 1,
+                                       subscription_master: subscription_master,
+                                       on_new_events: method(:on_new_events_callback),
+                                       batch_size: 42)
+
+    expect(event_store).to receive(:get_next_from).with(1, event_types: nil, limit: 42).and_return []
+
+    subscription.start
+  end
 end


### PR DESCRIPTION
Previously we didn't pass through a `limit` value to `EventStore#get_next_from` so the event store would use the [it's internal default of 1000](https://github.com/envato/event_sourcery-postgres/blob/a93ee97fe86c77dd5f7329adaf2c7c6203cf7520/lib/event_sourcery/postgres/event_store.rb#L54).

This PR adds a `subscription_batch_size` option that we pass through to the event store.