### PR TITLE
Allow passing an after_fork lambda to ESPRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Allow passing an `after_fork` lambda to `ESPRunner` that is called after each
+  `ESPProcess` is forked
+
 ## [0.18.0] - 2018-05-23
 
 - Allow specifying a subscription batch size

--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -1,18 +1,23 @@
 module EventSourcery
   module EventProcessing
     class ESPProcess
+      DEFAULT_AFTER_FORK = -> (event_processor) { }
+
       def initialize(event_processor:,
                      event_source:,
-                     subscription_master: EventStore::SignalHandlingSubscriptionMaster.new)
+                     subscription_master: EventStore::SignalHandlingSubscriptionMaster.new,
+                     after_fork:)
         @event_processor = event_processor
         @event_source = event_source
         @subscription_master = subscription_master
+        @after_fork = after_fork || DEFAULT_AFTER_FORK
       end
-      
+
       # This will start the Event Stream Processor which will subscribe
       # to the event stream source.
       def start
         name_process
+        @after_fork.call(@event_processor)
         error_handler.with_error_handling do
           EventSourcery.logger.info("Starting #{processor_name}")
           subscribe_to_event_stream

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -6,13 +6,15 @@ module EventSourcery
       def initialize(event_processors:,
                      event_source:,
                      max_seconds_for_processes_to_terminate: 30,
-                     shutdown_requested: false)
+                     shutdown_requested: false,
+                     after_fork: nil)
         @event_processors = event_processors
         @event_source = event_source
         @pids = []
         @max_seconds_for_processes_to_terminate = max_seconds_for_processes_to_terminate
         @shutdown_requested = shutdown_requested
         @exit_status = true
+        @after_fork = after_fork
       end
 
       # Start each Event Stream Processor in a new child process.
@@ -47,7 +49,8 @@ module EventSourcery
       def start_process(event_processor)
         process = ESPProcess.new(
           event_processor: event_processor,
-          event_source: @event_source
+          event_source: @event_source,
+          after_fork: @after_fork,
         )
         @pids << Process.fork { process.start }
       end

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
       event_processor: esp,
       event_source: event_source,
       subscription_master: subscription_master,
+      after_fork: after_fork,
     )
   end
   let(:esp) { spy(:esp, processor_name: processor_name, class: esp_class) }
@@ -12,6 +13,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
   let(:event_source) { spy(:event_source) }
   let(:subscription_master) { spy(EventSourcery::EventStore::SignalHandlingSubscriptionMaster) }
   let(:error_handler) { double }
+  let(:after_fork) { nil }
 
   describe '#start' do
     subject(:start) { esp_process.start }
@@ -52,6 +54,14 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
 
       it 'logs info when stopping ESP' do
         expect(logger).to have_received(:info).with("Stopping #{processor_name}")
+      end
+
+      context 'with after_fork set' do
+        let(:after_fork) { spy(:after_fork) }
+
+        it 'calls after_fork with the processor' do
+          expect(after_fork).to have_received(:call).with(esp)
+        end
       end
     end
 

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         .with(
           event_processor: esp,
           event_source: event_source,
+          after_fork: nil,
         )
       expect(esp_process).to have_received(:start)
     end


### PR DESCRIPTION
We're going to be using this to set the `application_name` on our Postgres connections so we can see where queries are coming from in `pg_stat_activity`.

``` ruby
after_fork = -> (event_processor) {
  [App.projections_database, App.event_store_database].each do |connection|
    processor_name = connection.literal(event_processor.processor_name)
    connection.execute("SET application_name TO '#{processor_name}'")
  end
}
```