### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.19.0] - 2018-06-06
 
 ### Added
 
@@ -136,7 +136,10 @@ moving all Postgres related code into a separate gem.
 - EventSourcery no longer depends on Virtus.
 - `Command` and `CommandHandler` have been removed.
 
-[Unreleased]: https://github.com/envato/event_sourcery/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/envato/event_sourcery/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/envato/event_sourcery/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/envato/event_sourcery/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/envato/event_sourcery/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/envato/event_sourcery/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/envato/event_sourcery/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/envato/event_sourcery/compare/v0.13.0...v0.14.0

--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,4 +1,4 @@
 module EventSourcery
   # Defines the version
-  VERSION = '0.18.0'.freeze
+  VERSION = '0.19.0'.freeze
 end


### PR DESCRIPTION
## [0.19.0] - 2018-06-06
 
### Added
 
- Allow passing an `after_fork` lambda to `ESPRunner` that is called after each `ESPProcess` is forked

[0.19.0]: https://github.com/envato/event_sourcery/compare/v0.18.0...v0.19.0