### PR TITLE
Update logging when a fatal exception occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Added more logging when a fatal exception occurs in ESPProcess
+
 ## [0.19.0] - 2018-06-06
 
 ### Added

--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -24,7 +24,8 @@ module EventSourcery
           EventSourcery.logger.info("Stopping #{@event_processor.processor_name}")
         end
       rescue Exception => e
-        EventSourcery.logger.error(e)
+        EventSourcery.logger.fatal("An unhandled exception occurred in #{processor_name}")
+        EventSourcery.logger.fatal(e)
         raise e
       end
 

--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -21,7 +21,7 @@ module EventSourcery
         error_handler.with_error_handling do
           EventSourcery.logger.info("Starting #{processor_name}")
           subscribe_to_event_stream
-          EventSourcery.logger.info("Stopping #{@event_processor.processor_name}")
+          EventSourcery.logger.info("Stopping #{processor_name}")
         end
       rescue Exception => e
         EventSourcery.logger.fatal("An unhandled exception occurred in #{processor_name}")

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
 
       it 'logs and re-raises the error' do
         expect { start }.to raise_error(error)
-        expect(logger).to have_received(:error).with(error)
+        expect(logger).to have_received(:fatal).with(error)
       end
     end
   end


### PR DESCRIPTION
At this point the process is going to die and won't be restart by ESPRunner, so use the `FATAL` log level and add an extra line of detail to make it easier to grep for this event.