### PR TITLE
Bugfix: cast status.success? to a boolean

### DIFF
--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -89,7 +89,7 @@ module EventSourcery
         until all_processes_terminated? ||
               ((pid, status) = Process.wait2(-1, Process::WNOHANG)).nil?
           @pids.delete(pid)
-          @exit_status &&= status.success?
+          @exit_status &&= !!status.success?
         end
       end
 


### PR DESCRIPTION
The return value can be nil if the process is still alive after being sent a KILL signal, for example with `max_seconds_for_processes_to_terminate` set to 0.

```
[1] pry(#<EventSourcery::EventProcessing::ESPRunner>)> status
=> #<Process::Status: pid 92671 SIGKILL (signal 9)>
```

This situation causes `Process.exit(nil)` to throw an error.