### PR TITLE
Update version number and add change log notes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.20.0] - 2018-06-21
 ### Changed
+- Changed signature of `ESPProcess#initialize` to include a default value for `after_fork`. This prevents the 
+`after_fork` change from 0.19.0 from being a breaking change to external creators of ESPProcess.
 - Added more logging when a fatal exception occurs in ESPProcess
 
 ## [0.19.0] - 2018-06-06
-
 ### Added
 
 - Allow passing an `after_fork` lambda to `ESPRunner` that is called after each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,10 +141,12 @@ moving all Postgres related code into a separate gem.
 - EventSourcery no longer depends on Virtus.
 - `Command` and `CommandHandler` have been removed.
 
-[Unreleased]: https://github.com/envato/event_sourcery/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/envato/event_sourcery/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/envato/event_sourcery/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/envato/event_sourcery/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/envato/event_sourcery/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/envato/event_sourcery/compare/v0.16.0...v0.17.0
+[0.16.1]: https://github.com/envato/event_sourcery/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/envato/event_sourcery/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/envato/event_sourcery/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/envato/event_sourcery/compare/v0.13.0...v0.14.0

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ bundle exec rspec
 To release a new version:
 
 1. Update the version number in `lib/event_sourcery/version.rb`
-2. Get this change onto master via the normal PR process
-3. Run `bundle exec rake release`, this will create a git tag for the
+2. Add the new version with release notes to CHANGELOG.md
+3. Get these changes onto master via the normal PR process
+4. Run `bundle exec rake release`, this will create a git tag for the
    version, push tags up to GitHub, and package the code in a `.gem` file.
 
 ## Core Concepts

--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,4 +1,4 @@
 module EventSourcery
   # Defines the version
-  VERSION = '0.19.0'.freeze
+  VERSION = '0.20.0'.freeze
 end


### PR DESCRIPTION
I've also updated the version process in the README.

For some reason I'm not getting an automated link on the [0.20.0] in the changelog like most of the other versions have (except [0.16.1])