### PR TITLE
Add back on_event_processor_error callback

### DIFF
--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -37,7 +37,7 @@ module EventSourcery
       @on_unknown_event = proc { |event, aggregate|
         raise AggregateRoot::UnknownEventError, "#{event.type} is unknown to #{aggregate.class.name}"
       }
-      @on_event_processor_error = proc { |exception, processor_name|
+      @on_event_processor_error = proc { |exception, event, processor|
         # app specific custom logic ie. report to an error reporting service like Rollbar.
       }
       @event_builder = nil

--- a/lib/event_sourcery/event_processing/event_stream_processor.rb
+++ b/lib/event_sourcery/event_processing/event_stream_processor.rb
@@ -31,7 +31,8 @@ module EventSourcery
             instance_exec(event, &handler)
           end
           @_event = nil
-        rescue
+        rescue => error
+          report_error(error, event)
           raise EventProcessingError.new(event: event, processor: self)
         end
       end
@@ -148,6 +149,10 @@ module EventSourcery
           EventSourcery.logger.debug { "[#{processor_name}] Processed event: #{event.inspect}" }
         end
         EventSourcery.logger.info { "[#{processor_name}] Processed up to event id: #{events.last.id}" }
+      end
+
+      def report_error(error, event)
+        EventSourcery.config.on_event_processor_error.call(error, event, self)
       end
     end
   end

--- a/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
+++ b/spec/event_sourcery/event_processing/event_stream_processor_spec.rb
@@ -259,6 +259,13 @@ RSpec.describe EventSourcery::EventProcessing::EventStreamProcessor do
             EOF
           }
         end
+
+        it 'calls the event processor error block' do
+          on_error = double(call: true)
+          allow(EventSourcery.config).to receive(:on_event_processor_error).and_return(on_error)
+          expect { event_processor.process(item_added_event) }.to raise_error(EventSourcery::EventProcessingError)
+          expect(on_error).to have_received(:call).with(an_instance_of(RuntimeError), item_added_event, event_processor)
+        end
       end
     end
 


### PR DESCRIPTION
This callback was removed a while ago. It's useful to be able to report errors within the context of the event and the processor, then the `EventProcessorError` can be ignored at the top level (in Rollbar config).