### PR TITLE
Wake up sleeping main thread upon receiving a signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Graceful shutdown interrupts poll-wait sleep for quicker quitting.
+
 ## [0.20.0] - 2018-06-21
 ### Changed
 - Changed signature of `ESPProcess#initialize` to include a default value for `after_fork`. This prevents the 


### PR DESCRIPTION
### Context

We have a custom event source with a long polling interval (5 minutes). This plays havoc with the Event Sourcery graceful shutdown mechanism as it will take up to 5 minutes to stop.

We set [`@shutdown_requested`](https://github.com/envato/event_sourcery/blob/5dc0ec1/lib/event_sourcery/event_store/signal_handling_subscription_master.rb#L24) upon receiving `SIGTERM`. But we only check [`@shutdown_request`](https://github.com/envato/event_sourcery/blob/20a2a2c71bd9a0972187222c868a1eab79cf7f59/lib/event_sourcery/event_store/subscription.rb#L51) after waking from the poll wait sleep.

### Change

Instruct the main thread to wake upon receiving `SIGTERM` or `SIGINT`. So we don't wait the remainder of the poll wait sleep.