### PR TITLE
Log unhandled exceptions to configured application block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Log unhandled exceptions to configured application block
+  ([#209](https://github.com/envato/event_sourcery/pull/209)).
+
 ## [0.21.0] - 2018-07-02
 ### Added
 - Graceful shutdown interrupts poll-wait sleep for quicker quitting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Log unhandled exceptions to configured application block
-  ([#209](https://github.com/envato/event_sourcery/pull/209)).
+- Log critical exceptions to the application provided block via the new
+  configuration option ([#209](https://github.com/envato/event_sourcery/pull/209)):
+
+  ```ruby
+  config.on_event_processor_critical_error = proc do |exception, processor_name|
+    # report the death of this processor to an error reporting service like Rollbar.
+  end
+  ```
 
 ## [0.21.0] - 2018-07-02
 ### Added

--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -19,6 +19,14 @@ module EventSourcery
     # @return Proc
     attr_accessor :on_event_processor_error
 
+    # A Proc to be executed on an event processor critical error.
+    # App defined behaviour can be provided. This will be called
+    # if an exception causes an a event processor to die.
+    # i.e. report to an error reporting service like Rollbar.
+    #
+    # @return Proc
+    attr_accessor :on_event_processor_critical_error
+
     # @return EventStore::EventTypeSerializers::Underscored
     attr_accessor :event_type_serializer
 
@@ -38,6 +46,9 @@ module EventSourcery
         raise AggregateRoot::UnknownEventError, "#{event.type} is unknown to #{aggregate.class.name}"
       }
       @on_event_processor_error = proc { |exception, processor_name|
+        # app specific custom logic ie. report to an error reporting service like Rollbar.
+      }
+      @on_event_processor_critical_error = proc { |exception, processor_name|
         # app specific custom logic ie. report to an error reporting service like Rollbar.
       }
       @event_builder = nil

--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -26,7 +26,7 @@ module EventSourcery
       rescue Exception => e
         EventSourcery.logger.fatal("An unhandled exception occurred in #{processor_name}")
         EventSourcery.logger.fatal(e)
-        EventSourcery.config.on_event_processor_error.call(e, processor_name)
+        EventSourcery.config.on_event_processor_critical_error.call(e, processor_name)
         raise e
       end
 

--- a/lib/event_sourcery/event_processing/esp_process.rb
+++ b/lib/event_sourcery/event_processing/esp_process.rb
@@ -26,6 +26,7 @@ module EventSourcery
       rescue Exception => e
         EventSourcery.logger.fatal("An unhandled exception occurred in #{processor_name}")
         EventSourcery.logger.fatal(e)
+        EventSourcery.config.on_event_processor_error.call(e, processor_name)
         raise e
       end
 

--- a/spec/event_sourcery/config_spec.rb
+++ b/spec/event_sourcery/config_spec.rb
@@ -16,4 +16,3 @@ RSpec.describe EventSourcery::Config do
     end
   end
 end
-

--- a/spec/event_sourcery/config_spec.rb
+++ b/spec/event_sourcery/config_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe EventSourcery::Config do
+  subject(:config) { described_class.new }
+
+  describe '#on_event_processor_critical_error' do
+    subject(:on_event_processor_critical_error) { config.on_event_processor_critical_error }
+
+    it 'has a default block set' do
+      expect(on_event_processor_critical_error).to_not be_nil
+      expect { on_event_processor_critical_error.call(nil, nil) }.to_not raise_error
+    end
+
+    it 'can set a block' do
+      block = Object.new
+      config.on_event_processor_critical_error = block
+      expect(on_event_processor_critical_error).to be(block)
+    end
+  end
+end
+

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
   let(:subscription_master) { spy(EventSourcery::EventStore::SignalHandlingSubscriptionMaster) }
   let(:error_handler) { double }
   let(:after_fork) { nil }
+  let(:on_event_processor_error) { spy }
 
   describe '#start' do
     subject(:start) { esp_process.start }
@@ -23,6 +24,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
       allow(EventSourcery.config.error_handler_class).to receive(:new)
         .with(processor_name: processor_name).and_return(error_handler)
       allow(EventSourcery).to receive(:logger).and_return(logger)
+      allow(EventSourcery.config).to receive(:on_event_processor_error).and_return(on_event_processor_error)
     end
 
     context 'when no error is raised' do
@@ -91,6 +93,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
       it 'logs and re-raises the error' do
         expect { start }.to raise_error(error)
         expect(logger).to have_received(:fatal).with(error)
+        expect(on_event_processor_error).to have_received(:call).with(error, processor_name)
       end
     end
   end

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
   let(:subscription_master) { spy(EventSourcery::EventStore::SignalHandlingSubscriptionMaster) }
   let(:error_handler) { double }
   let(:after_fork) { nil }
-  let(:on_event_processor_error) { spy }
+  let(:on_event_processor_critical_error) { spy }
 
   describe '#start' do
     subject(:start) { esp_process.start }
@@ -24,7 +24,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
       allow(EventSourcery.config.error_handler_class).to receive(:new)
         .with(processor_name: processor_name).and_return(error_handler)
       allow(EventSourcery).to receive(:logger).and_return(logger)
-      allow(EventSourcery.config).to receive(:on_event_processor_error).and_return(on_event_processor_error)
+      allow(EventSourcery.config).to receive(:on_event_processor_critical_error).and_return(on_event_processor_critical_error)
     end
 
     context 'when no error is raised' do
@@ -91,7 +91,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
       it 'logs and re-raises the error' do
         expect { start }.to raise_error(error)
         expect(logger).to have_received(:fatal).with(error)
-        expect(on_event_processor_error).to have_received(:call).with(error, processor_name)
+        expect(on_event_processor_critical_error).to have_received(:call).with(error, processor_name)
       end
     end
   end

--- a/spec/event_sourcery/event_processing/esp_process_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_process_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
     context 'when no error is raised' do
       before do
         allow(error_handler).to receive(:with_error_handling).and_yield
-        allow(logger).to receive(:info)
         allow(Process).to receive(:setproctitle)
 
         allow(esp).to receive(:subscribe_to)
@@ -87,7 +86,6 @@ RSpec.describe EventSourcery::EventProcessing::ESPProcess do
 
       before do
         allow(error_handler).to receive(:with_error_handling).and_raise(error)
-        allow(logger).to receive(:error).with(error)
       end
 
       it 'logs and re-raises the error' do


### PR DESCRIPTION
### Context

We've been trying to track down an exception that's been killing our process. Rather than sifting through the logs it'd be nice to see this error in Rollbar.

### Change

Handle uncaught exceptions with the application configured block. (In our case it logs to Rollbar.)