### PR TITLE
Test on Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.3
 - 2.4
 - 2.5
+- 2.6
 before_install:
 - gem install bundler
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Add Ruby 2.6 to the CI test matrix.
+
 ## [0.22.0] - 2018-10-04
 ### Added
 - Log critical exceptions to the application provided block via the new


### PR DESCRIPTION
Ruby 2.6 has been [released](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/)! Let's add it to the test matrix.

<img width="767" alt="image" src="https://user-images.githubusercontent.com/497874/50582557-871adf00-0eb7-11e9-8645-529391887e04.png">
