### PR TITLE
Fix the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.4
 - 2.5
 before_install:
+- gem update --system
 - gem install bundler
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2
 - 2.3
 - 2.4
 - 2.5

--- a/event_sourcery.gemspec
+++ b/event_sourcery.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Since Bundler 2.0 was released, our build has failed:

![image](https://user-images.githubusercontent.com/497874/50671156-47bdd100-1024-11e9-8dee-c5a762f22dd0.png)

In our CI we install the [latest version of Bundler (2.0.1)](https://travis-ci.org/envato/event_sourcery/jobs/475125785#L469), but our gemspec [specifies we must use `~> 1.10`](https://travis-ci.org/envato/event_sourcery/jobs/475125785#L469) which excludes version 2.

To fix this:

* remove the constraint on the Bundler version from the gemspec
* ensure the latest version of Rubygems is installed, and
* remove Ruby 2.2 from the build matrix (Bundler 2.0 is not available on this version of Ruby)

![image](https://user-images.githubusercontent.com/497874/50671419-e5fe6680-1025-11e9-8838-a7d5a7bbb638.png)
