### PR TITLE
Fix the broken reference to memory store in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The event store is a persistent store of events.
 
 EventSourcery currently supports a Postgres-based event store via the [event_sourcery-postgres gem](https://github.com/envato/event_sourcery-postgres).
 
-For more information about the `EventStore` API refer to [the postgres event store](https://github.com/envato/event_sourcery-postgres/blob/master/lib/event_sourcery/postgres/event_store.rb) or the [in memory event store in this repo](lib/event_sourcery/event_store/memory.rb)
+For more information about the `EventStore` API refer to [the postgres event store](https://github.com/envato/event_sourcery-postgres/blob/master/lib/event_sourcery/postgres/event_store.rb) or the [in memory event store in this repo](lib/event_sourcery/memory/event_store.rb)
 
 #### Storing Events
 


### PR DESCRIPTION
It looks like README references a non-existing file in the repo.
Presumably, it was moved at some point. This change should link to the correct file now.