### PR TITLE
Default to INFO level

### DIFF
--- a/lib/event_sourcery/config.rb
+++ b/lib/event_sourcery/config.rb
@@ -58,10 +58,10 @@ module EventSourcery
     end
 
     # Logger instance used by EventSourcery.
-    # By default EventSourcery will log to STDOUT with a log level of Logger::DEBUG
+    # By default EventSourcery will log to STDOUT with a log level of Logger::INFO
     def logger
       @logger ||= ::Logger.new(STDOUT).tap do |logger|
-        logger.level = Logger::DEBUG
+        logger.level = Logger::INFO
       end
     end
 


### PR DESCRIPTION
The default log level is not sane for production systems. Services have been known to produce more than 50GB of logs per day with DEBUG level enabled.