### PR TITLE
ESPRunner shuts down after a child process terminates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add Ruby 2.6 to the CI test matrix.
+- Added `shutdown_if_child_process_fails` option to the `ESPRunner` class.
+  This option will cause the `ESPRunner` to shutdown all child processes and
+  exit if any one child process prematurely terminates.
 
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.
 
-### Changed
-- Changed `ESPRunner` so that it shuts down all child processes if one
-  prematurely terminates.
 
 ## [0.22.0] - 2018-10-04
 ### Added
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.20.0] - 2018-06-21
 ### Changed
-- Changed signature of `ESPProcess#initialize` to include a default value for `after_fork`. This prevents the 
+- Changed signature of `ESPProcess#initialize` to include a default value for `after_fork`. This prevents the
 `after_fork` change from 0.19.0 from being a breaking change to external creators of ESPProcess.
 - Added more logging when a fatal exception occurs in ESPProcess
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.
 
+### Changed
+- Changed `ESPRunner` so that it shuts down all child processes if one
+  prematurely terminates.
+
 ## [0.22.0] - 2018-10-04
 ### Added
 - Log critical exceptions to the application provided block via the new


### PR DESCRIPTION
We're encountering a problem when running our event processors via the `ESPRunner`. When one of the event processors running in a child process fails and terminates prematurely, the `ESPRunner` just ignores the problem. Eventually, our event processor lag monitor will raise the alert to the on-call developer, who in turn can manually restart the ESPRunner.

The process status list looks something like this:
```
> ps aux
USER     PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
app        1  0.0  1.6  90992 65204 ?        Ssl  03:40   0:02 ruby /app/script/processors
app        2  0.1  1.7  93624 68692 ?        Sl   03:40   0:04 MyApp::Queries::Projector1
app        3  0.0  0.0      0     0 ?        Z    03:40   0:03 [ruby] <defunct>
app        4  0.1  1.6  93640 67660 ?        Sl   03:40   0:05 MyApp::Queries::Projector3
```

### Change

I propose that instead of ignoring the terminated child process, the `ESPRunner` could optionally consider this a catastrophic failure and (gracefully) stop the remaining child processes, before exiting itself with a status code indicating error. This would allow us to identify the problem earlier, and automatically resolve the problem by restarting the `ESPRunner`.

#### Test Documentation

```
EventSourcery::EventProcessing::ESPRunner
  start!
    starts ESP processes
    graceful shutdown
      upon receiving a TERM signal
        it starts to shutdown
      upon receiving a INT signal
        it starts to shutdown
      sends processes the TERM signal
      exits indicating success
      given shutdown has been requested
        but the processes failed before shutdown
          doesn't send processes the TERM, or KILL signal to the failed process
          exits indicating failure
      given shutdown has not been requested
        and we've requested shutdown if a child process fails
          and the processes fail
            starts the shutdown process after being notified of the failure
            doesn't send processes the TERM, or KILL signal to the failed process
            exits indicating failure
      given the process exits just before sending signal
        doesn't send the signal more than once
        exits indicating failure
      given the process does not terminate until killed
        sends processes the KILL signal
        exits indicating failure
```

### Considerations

I'm not convinced the EventSourcery gem should be responsible for such process management. We should probably be moving this functionality to a gem like [Forked](https://github.com/envato/forked).