### PR TITLE
ESPRunner hook for responding to event processor failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add Ruby 2.6 to the CI test matrix.
+- `ESPRunner` supports an `after_subprocess_termination` hook. This optional
+  initializer argument will will be executed when each child process
+  terminates. This allows for monitoring and alerts to be configured.
+  For example, Rollbar:
+
+  ```ruby
+  EventSourcery::EventProcessing::ESPRunner.new(
+    event_processors: processors,
+    event_source: source,
+    after_subprocess_termination: proc do |processor:, runner:, exit_status:|
+      if exit_status != 0
+        Rollbar.error("Processor #{processor.processor_name} "\
+                      "terminated with exit status #{exit_status}")
+      end
+    end
+  ).start!
+  ```
+
 - `ESPRunner` checks for dead child processes every second. This means we
   shouldn't see `[ruby] <defunct>` in the process list (ps) when a processor
   fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add Ruby 2.6 to the CI test matrix.
+- `ESPRunner` checks for dead child processes every second. This means we
+  shouldn't see `[ruby] <defunct>` in the process list (ps) when a processor
+  fails.
 
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.
@@ -36,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.20.0] - 2018-06-21
 ### Changed
-- Changed signature of `ESPProcess#initialize` to include a default value for `after_fork`. This prevents the 
+- Changed signature of `ESPProcess#initialize` to include a default value for `after_fork`. This prevents the
 `after_fork` change from 0.19.0 from being a breaking change to external creators of ESPProcess.
 - Added more logging when a fatal exception occurs in ESPProcess
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `ESPRunner` checks for dead child processes every second. This means we
   shouldn't see `[ruby] <defunct>` in the process list (ps) when a processor
   fails.
+- `ESPRunner` logs when child processes die.
 
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ).start!
   ```
 
+- `ESPRunner` exposes three new public methods `start_processor`, `shutdown`,
+  and `shutdown_requested?`. These provide options for handling subprocess
+  failure/termination. For example, shutting down the `ESPRunner`:
+
+  ```ruby
+  EventSourcery::EventProcessing::ESPRunner.new(
+    event_processors: processors,
+    event_source: source,
+    after_subprocess_termination: proc do |processor:, runner:, exit_status:|
+      runner.shutdown
+    end
+  ).start!
+  ```
+
+  Or restarting the event processor:
+
+  ```ruby
+  EventSourcery::EventProcessing::ESPRunner.new(
+    event_processors: processors,
+    event_source: source,
+    after_subprocess_termination: proc do |processor:, runner:, exit_status:|
+      runner.start_processor(processor) unless runner.shutdown_requested?
+    end
+  ).start!
+  ```
+
 - `ESPRunner` checks for dead child processes every second. This means we
   shouldn't see `[ruby] <defunct>` in the process list (ps) when a processor
   fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   shouldn't see `[ruby] <defunct>` in the process list (ps) when a processor
   fails.
 - `ESPRunner` logs when child processes die.
+- `ESPRunner` logs when sending signals to child processes.
 
 ### Removed
 - Remove Ruby 2.2 from the CI test matrix.

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -78,10 +78,10 @@ module EventSourcery
       end
 
       def while_waiting_for_shutdown
-        yield
-        until shutdown_requested?
-          sleep(1)
+        loop do
           yield
+          break if shutdown_requested?
+          sleep(1)
         end
       end
 

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -38,9 +38,9 @@ module EventSourcery
       private
 
       def with_logging
-        logger.info('Forking ESP processes')
+        logger.info('ESPRunner: Forking processes')
         yield
-        logger.info('ESP processes shutdown')
+        logger.info('ESPRunner: Processes shutdown')
       end
 
       def start_processes
@@ -87,7 +87,7 @@ module EventSourcery
       def send_signal_to_remaining_processes(signal)
         return if all_processes_terminated?
 
-        logger.info("Sending #{signal} to [#{@pids.values.map(&:processor_name).join(', ')}]")
+        logger.info("ESPRunner: Sending #{signal} to [#{@pids.values.map(&:processor_name).join(', ')}]")
         Process.kill(signal, *@pids.keys)
       rescue Errno::ESRCH
         record_terminated_processes
@@ -98,7 +98,7 @@ module EventSourcery
         until all_processes_terminated? || (pid, status = Process.wait2(-1, Process::WNOHANG)).nil?
           event_processor = @pids.delete(pid)
           @exit_status &&= !!status.success?
-          logger.info("Process #{event_processor.processor_name} terminated with exit status: #{status.exitstatus.inspect}")
+          logger.info("ESPRunner: Process #{event_processor.processor_name} terminated with exit status: #{status.exitstatus.inspect}")
         end
       end
 

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -87,6 +87,7 @@ module EventSourcery
       def send_signal_to_remaining_processes(signal)
         return if all_processes_terminated?
 
+        logger.info("Sending #{signal} to [#{@pids.values.map(&:processor_name).join(', ')}]")
         Process.kill(signal, *@pids.keys)
       rescue Errno::ESRCH
         record_terminated_processes

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -38,9 +38,9 @@ module EventSourcery
       private
 
       def with_logging
-        EventSourcery.logger.info { 'Forking ESP processes' }
+        logger.info('Forking ESP processes')
         yield
-        EventSourcery.logger.info { 'ESP processes shutdown' }
+        logger.info('ESP processes shutdown')
       end
 
       def start_processes
@@ -95,8 +95,9 @@ module EventSourcery
 
       def record_terminated_processes
         until all_processes_terminated? || (pid, status = Process.wait2(-1, Process::WNOHANG)).nil?
-          @pids.delete(pid)
+          event_processor = @pids.delete(pid)
           @exit_status &&= !!status.success?
+          logger.info("Process #{event_processor.processor_name} terminated with exit status: #{status.exitstatus.inspect}")
         end
       end
 
@@ -111,6 +112,10 @@ module EventSourcery
 
       def exit_indicating_status_of_processes
         Process.exit(@exit_status)
+      end
+
+      def logger
+        EventSourcery.logger
       end
     end
   end

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -8,6 +8,7 @@ module EventSourcery
                      max_seconds_for_processes_to_terminate: 30,
                      shutdown_requested: false,
                      after_fork: nil,
+                     after_subprocess_termination: nil,
                      logger: EventSourcery.logger)
         @event_processors = event_processors
         @event_source = event_source
@@ -16,6 +17,7 @@ module EventSourcery
         @shutdown_requested = shutdown_requested
         @exit_status = true
         @after_fork = after_fork
+        @after_subprocess_termination = after_subprocess_termination
         @logger = logger
       end
 
@@ -102,6 +104,7 @@ module EventSourcery
           event_processor = @pids.delete(pid)
           @exit_status &&= !!status.success?
           logger.info("ESPRunner: Process #{event_processor.processor_name} terminated with exit status: #{status.exitstatus.inspect}")
+          @after_subprocess_termination&.call(processor: event_processor, runner: self, exit_status: status.exitstatus)
         end
       end
 

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -7,7 +7,8 @@ module EventSourcery
                      event_source:,
                      max_seconds_for_processes_to_terminate: 30,
                      shutdown_requested: false,
-                     after_fork: nil)
+                     after_fork: nil,
+                     logger: EventSourcery.logger)
         @event_processors = event_processors
         @event_source = event_source
         @pids = {}
@@ -15,6 +16,7 @@ module EventSourcery
         @shutdown_requested = shutdown_requested
         @exit_status = true
         @after_fork = after_fork
+        @logger = logger
       end
 
       # Start each Event Stream Processor in a new child process.
@@ -36,6 +38,8 @@ module EventSourcery
       end
 
       private
+
+      attr_reader :logger
 
       def with_logging
         logger.info('ESPRunner: Forking processes')
@@ -83,7 +87,6 @@ module EventSourcery
         send_signal_to_remaining_processes(:KILL)
       end
 
-
       def send_signal_to_remaining_processes(signal)
         return if all_processes_terminated?
 
@@ -113,10 +116,6 @@ module EventSourcery
 
       def exit_indicating_status_of_processes
         Process.exit(@exit_status)
-      end
-
-      def logger
-        EventSourcery.logger
       end
     end
   end

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -68,12 +68,12 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
 
       it "logs the TERM signal" do
         start!
-        expect(logger).to have_received(:info).with("Sending TERM to [#{processor_name}]")
+        expect(logger).to have_received(:info).with("ESPRunner: Sending TERM to [#{processor_name}]")
       end
 
       it "logs the process exit status" do
         start!
-        expect(logger).to have_received(:info).with("Process #{processor_name} terminated with exit status: 0")
+        expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 0")
       end
 
       it "exits indicating success" do
@@ -91,7 +91,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
 
           it "logs the process exit status" do
             start!
-            expect(logger).to have_received(:info).with("Process #{processor_name} terminated with exit status: 1")
+            expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 1")
           end
 
           it "doesn't send processes the TERM, or KILL signal to the failed process" do
@@ -119,7 +119,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
 
         it "logs the process exit status" do
           start!
-          expect(logger).to have_received(:info).with("Process #{processor_name} terminated with exit status: 1")
+          expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 1")
         end
 
         it "exits indicating failure" do
@@ -142,12 +142,12 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
 
         it "logs the KILL signal" do
           start!
-          expect(logger).to have_received(:info).with("Sending KILL to [#{processor_name}]")
+          expect(logger).to have_received(:info).with("ESPRunner: Sending KILL to [#{processor_name}]")
         end
 
         it "logs the process exit status" do
           start!
-          expect(logger).to have_received(:info).with("Process #{processor_name} terminated with exit status: 1")
+          expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 1")
         end
 
         it "exits indicating failure" do

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -66,6 +66,11 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         expect(Process).to have_received(:kill).with(:TERM, pid)
       end
 
+      it "logs the TERM signal" do
+        start!
+        expect(logger).to have_received(:info).with("Sending TERM to [#{processor_name}]")
+      end
+
       it "logs the process exit status" do
         start!
         expect(logger).to have_received(:info).with("Process #{processor_name} terminated with exit status: 0")
@@ -133,6 +138,11 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         it 'sends processes the KILL signal' do
           start!
           expect(Process).to have_received(:kill).with(:KILL, pid)
+        end
+
+        it "logs the KILL signal" do
+          start!
+          expect(logger).to have_received(:info).with("Sending KILL to [#{processor_name}]")
         end
 
         it "logs the process exit status" do

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
       event_processors: event_processors,
       event_source: event_source,
       max_seconds_for_processes_to_terminate: 0.01,
-      shutdown_requested: shutdown_requested
+      shutdown_requested: shutdown_requested,
+      logger: logger,
     )
   end
   let(:event_source) { spy(:event_source) }
@@ -29,7 +30,6 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
     allow(Signal).to receive(:trap)
     allow(esp_runner).to receive(:shutdown)
     allow(esp_runner).to receive(:sleep)
-    allow(EventSourcery).to receive(:logger).and_return(logger)
   end
 
   describe 'start!' do

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -36,10 +36,6 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
   describe 'start!' do
     subject(:start!) { esp_runner.start! }
 
-    before do
-      allow(esp_runner).to receive(:shutdown)
-    end
-
     it 'starts ESP processes' do
       start!
       expect(EventSourcery::EventProcessing::ESPProcess)
@@ -57,6 +53,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         context "upon receiving a #{signal} signal" do
           before do
             allow(Signal).to receive(:trap).with(signal).and_yield
+            allow(esp_runner).to receive(:shutdown)
           end
 
           it 'it starts to shutdown' do

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
       event_source: event_source,
       max_seconds_for_processes_to_terminate: 0.01,
       shutdown_requested: shutdown_requested,
+      after_subprocess_termination: after_subprocess_termination,
       logger: logger,
     )
   end
@@ -17,6 +18,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
   let(:success_status) { instance_double(Process::Status, success?: true, exitstatus: 0) }
   let(:failure_status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
   let(:shutdown_requested) { true }
+  let(:after_subprocess_termination) { nil }
   let(:logger) { instance_spy(Logger) }
 
   before do
@@ -76,6 +78,16 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 0")
       end
 
+      context 'given an after subprocess termination hook' do
+        let(:after_subprocess_termination) { spy }
+
+        it 'calls the after subprocess termination' do
+          start!
+          expect(after_subprocess_termination).to have_received(:call)
+            .with(processor: esp, runner: esp_runner, exit_status: 0)
+        end
+      end
+
       it "exits indicating success" do
         start!
         expect(Process).to have_received(:exit).with(true)
@@ -99,6 +111,16 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
             expect(Process).to_not have_received(:kill)
           end
 
+          context 'given an after subprocess termination hook' do
+            let(:after_subprocess_termination) { spy }
+
+            it 'calls the after subprocess termination' do
+              start!
+              expect(after_subprocess_termination).to have_received(:call)
+                .with(processor: esp, runner: esp_runner, exit_status: 1)
+            end
+          end
+
           it 'exits indicating failure' do
             start!
             expect(Process).to have_received(:exit).with(false)
@@ -120,6 +142,16 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         it "logs the process exit status" do
           start!
           expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 1")
+        end
+
+        context 'given an after subprocess termination hook' do
+          let(:after_subprocess_termination) { spy }
+
+          it 'calls the after subprocess termination' do
+            start!
+            expect(after_subprocess_termination).to have_received(:call)
+              .with(processor: esp, runner: esp_runner, exit_status: 1)
+          end
         end
 
         it "exits indicating failure" do
@@ -148,6 +180,16 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         it "logs the process exit status" do
           start!
           expect(logger).to have_received(:info).with("ESPRunner: Process #{processor_name} terminated with exit status: 1")
+        end
+
+        context 'given an after subprocess termination hook' do
+          let(:after_subprocess_termination) { spy }
+
+          it 'calls the after subprocess termination' do
+            start!
+            expect(after_subprocess_termination).to have_received(:call)
+              .with(processor: esp, runner: esp_runner, exit_status: 1)
+          end
         end
 
         it "exits indicating failure" do

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
       event_processors: event_processors,
       event_source: event_source,
       max_seconds_for_processes_to_terminate: 0.01,
-      shutdown_requested: true
+      shutdown_requested: shutdown_requested
     )
   end
   let(:event_source) { spy(:event_source) }
@@ -15,6 +15,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
   let(:pid) { 363_298 }
   let(:success_status) { instance_double(Process::Status, success?: true) }
   let(:failure_status) { instance_double(Process::Status, success?: false) }
+  let(:shutdown_requested) { true }
 
   before do
     allow(EventSourcery::EventProcessing::ESPProcess)
@@ -26,6 +27,7 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
     allow(Process).to receive(:exit)
     allow(Signal).to receive(:trap)
     allow(esp_runner).to receive(:shutdown)
+    allow(esp_runner).to receive(:sleep)
   end
 
   describe 'start!' do
@@ -67,19 +69,23 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
         expect(Process).to have_received(:exit).with(true)
       end
 
-      context 'given the processes failed before shutdown' do
-        before do
-          allow(Process).to receive(:wait2).and_return([pid, failure_status])
-        end
+      context 'given shutdown has been requested' do
+        let(:shutdown_requested) { true }
 
-        it "doesn't send processes the TERM, or KILL signal" do
-          start!
-          expect(Process).to_not have_received(:kill)
-        end
+        context 'but the processes failed before shutdown' do
+          before do
+            allow(Process).to receive(:wait2).and_return([pid, failure_status])
+          end
 
-        it "exits indicating failure" do
-          start!
-          expect(Process).to have_received(:exit).with(false)
+          it "doesn't send processes the TERM, or KILL signal to the failed process" do
+            start!
+            expect(Process).to_not have_received(:kill)
+          end
+
+          it 'exits indicating failure' do
+            start!
+            expect(Process).to have_received(:exit).with(false)
+          end
         end
       end
 


### PR DESCRIPTION
We're encountering a problem when running our event processors via the `ESPRunner`. When one of the event processors running in a child process fails and terminates prematurely, the `ESPRunner` just ignores the problem. Eventually, our event processor lag monitor will raise the alert to the on-call developer, who in turn can manually restart the ESPRunner.

The process status list looks something like this:
```
> ps aux
USER     PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
app        1  0.0  1.6  90992 65204 ?        Ssl  03:40   0:02 ruby /app/script/processors
app        2  0.1  1.7  93624 68692 ?        Sl   03:40   0:04 MyApp::Queries::Projector1
app        3  0.0  0.0      0     0 ?        Z    03:40   0:03 [ruby] <defunct>
app        4  0.1  1.6  93640 67660 ?        Sl   03:40   0:05 MyApp::Queries::Projector3
```

We explored adding an extra option where the `ESPRunner` would shutdown in such a scenario in #215.

### Change

This PR proposes a more extensible solution: provide a hook for the event processor failure. This'll allow teams to choose and implement an appropriate response as they see fit. Here're a few examples:


#### Report to Rollbar

  ```ruby
  EventSourcery::EventProcessing::ESPRunner.new(
    event_processors: processors,
    event_source: source,
    after_subprocess_termination: proc do |processor:, runner:, exit_status:|
      if exit_status != 0
        Rollbar.error("Processor #{processor.processor_name} "\
                      "terminated with exit status #{exit_status}")
      end
    end
  ).start!
  ```

#### Shutdown the ESPRunner

  ```ruby
  EventSourcery::EventProcessing::ESPRunner.new(
    event_processors: processors,
    event_source: source,
    after_subprocess_termination: proc do |processor:, runner:, exit_status:|
      runner.shutdown
    end
  ).start!
  ```

#### Restart the event processor

  ```ruby
  EventSourcery::EventProcessing::ESPRunner.new(
    event_processors: processors,
    event_source: source,
    after_subprocess_termination: proc do |processor:, runner:, exit_status:|
      runner.start_processor(processor) unless runner.shutdown_requested?
    end
  ).start!
  ```



