### PR TITLE
Update Rake to version 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Upgrade development dependency Rake to version 13. This resolves
+  [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8).
 
 ## [0.23.0] - 2019-07-11
 ### Added

--- a/event_sourcery.gemspec
+++ b/event_sourcery.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
This resolves the security issue: CVE-2020-8130.