### PR TITLE
Gracefully handle terminating subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgrade development dependency Rake to version 13. This resolves
   [CVE-2020-8130](https://github.com/advisories/GHSA-jppv-gw3r-w3q8).
 
+- Patch `ESPRunner` to gracefully handle terminating subprocesses it did
+  not start ([#223]).
+
+[#223]: https://github.com/envato/event_sourcery/pull/223
+
 ## [0.23.0] - 2019-07-11
 ### Added
 - Add Ruby 2.6 to the CI test matrix.

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -106,9 +106,10 @@ module EventSourcery
       def record_terminated_processes
         until all_processes_terminated? || (pid, status = Process.wait2(-1, Process::WNOHANG)).nil?
           event_processor = @pids.delete(pid)
+          logger.info("ESPRunner: Process #{event_processor&.processor_name || pid} " \
+                      "terminated with exit status: #{status.exitstatus.inspect}")
           next unless event_processor
           @exit_status &&= !!status.success?
-          logger.info("ESPRunner: Process #{event_processor.processor_name} terminated with exit status: #{status.exitstatus.inspect}")
           @after_subprocess_termination&.call(processor: event_processor, runner: self, exit_status: status.exitstatus)
         end
       end

--- a/lib/event_sourcery/event_processing/esp_runner.rb
+++ b/lib/event_sourcery/event_processing/esp_runner.rb
@@ -106,6 +106,7 @@ module EventSourcery
       def record_terminated_processes
         until all_processes_terminated? || (pid, status = Process.wait2(-1, Process::WNOHANG)).nil?
           event_processor = @pids.delete(pid)
+          next unless event_processor
           @exit_status &&= !!status.success?
           logger.info("ESPRunner: Process #{event_processor.processor_name} terminated with exit status: #{status.exitstatus.inspect}")
           @after_subprocess_termination&.call(processor: event_processor, runner: self, exit_status: status.exitstatus)

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -197,6 +197,26 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
           expect(Process).to have_received(:exit).with(false)
         end
       end
+
+      context 'given an unknown subprocess terminates' do
+        before do
+          allow(Process).to receive(:wait2).and_return(nil, [pid + 1, success_status], [pid, success_status])
+        end
+
+        it 'only logs the exit status for the known process' do
+          start!
+          expect(logger).to have_received(:info).with(/^ESPRunner: Process /).once
+        end
+
+        context 'given an after subprocess termination hook' do
+          let(:after_subprocess_termination) { spy }
+
+          it 'calls the after subprocess termination only once (for the known process)' do
+            start!
+            expect(after_subprocess_termination).to have_received(:call).once
+          end
+        end
+      end
     end
   end
 

--- a/spec/event_sourcery/event_processing/esp_runner_spec.rb
+++ b/spec/event_sourcery/event_processing/esp_runner_spec.rb
@@ -203,9 +203,16 @@ RSpec.describe EventSourcery::EventProcessing::ESPRunner do
           allow(Process).to receive(:wait2).and_return(nil, [pid + 1, success_status], [pid, success_status])
         end
 
-        it 'only logs the exit status for the known process' do
+        it 'only logs the exit status for both the known and unknown process' do
           start!
-          expect(logger).to have_received(:info).with(/^ESPRunner: Process /).once
+          expect(logger)
+            .to have_received(:info)
+            .with("ESPRunner: Process #{pid + 1} terminated with exit status: 0")
+            .once
+          expect(logger)
+            .to have_received(:info)
+            .with("ESPRunner: Process #{processor_name} terminated with exit status: 0")
+            .once
         end
 
         context 'given an after subprocess termination hook' do


### PR DESCRIPTION
It has been found that the `ESPRunner` class would fail when notified of a terminated process it didn't start.

```
NoMethodError: undefined method `processor_name' for nil:NilClass
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:110:in `record_terminated_processes'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:30:in `block (2 levels) in start!'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:82:in `block in while_waiting_for_shutdown'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:81:in `loop'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:81:in `while_waiting_for_shutdown'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:29:in `block in start!'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:66:in `with_logging'
/usr/local/bundle/gems/event_sourcery-0.23.0/lib/event_sourcery/event_processing/esp_runner.rb:26:in `start!'
```

Gracefully handle this situation by ignoring these notifications.