### PR TITLE
Resolve warnings raised by Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
 - 2.4
 - 2.5
 - 2.6
+- 2.7
 before_install:
 - gem update --system
 - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Patch `ESPRunner` to gracefully handle terminating subprocesses it did
   not start ([#223]).
 
+- Resolve warnings raised by Ruby 2.7 ([#225]).
+
 [#223]: https://github.com/envato/event_sourcery/pull/223
+[#225]: https://github.com/envato/event_sourcery/pull/225
 
 ## [0.23.0] - 2019-07-11
 ### Added

--- a/lib/event_sourcery/event_store/event_builder.rb
+++ b/lib/event_sourcery/event_store/event_builder.rb
@@ -5,10 +5,10 @@ module EventSourcery
         @event_type_serializer = event_type_serializer
       end
 
-      def build(event_data)
+      def build(**event_data)
         type = event_data.fetch(:type)
         klass = event_type_serializer.deserialize(type)
-        upcast(klass.new(event_data))
+        upcast(klass.new(**event_data))
       end
 
       private

--- a/lib/event_sourcery/rspec/event_store_shared_examples.rb
+++ b/lib/event_sourcery/rspec/event_store_shared_examples.rb
@@ -212,9 +212,9 @@ RSpec.shared_examples 'an event store' do
       end
     end
 
-    def events_by_range(*args)
+    def events_by_range(from_event_id, to_event_id, **args)
       [].tap do |events|
-        event_store.each_by_range(*args) do |event|
+        event_store.each_by_range(from_event_id, to_event_id, **args) do |event|
           events << event
         end
       end


### PR DESCRIPTION
Resolve the following warnings raised when running on Ruby 2.7.

```
/event_sourcery/lib/event_sourcery/event_store/event_builder.rb:11: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/event_sourcery/lib/event_sourcery/event.rb:78: warning: The called method `initialize' is defined here

/event_sourcery/lib/event_sourcery/rspec/event_store_shared_examples.rb:217: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/event_sourcery/lib/event_sourcery/event_store/each_by_range.rb:4: warning: The called method `each_by_range' is defined here
```