### PR TITLE
Remove Ruby 2.3, 2.4 and 2.5 from the CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - This project now uses `main` as its default branch ([#230]).
   - Documentation updated to refer to `main` and links updated accordingly.
 
+### Removed
+- Remove Ruby 2.3, 2.4 and 2.5 from the CI test matrix ([#232]).
+
 [#228]: https://github.com/envato/event_sourcery/pull/228
 [#229]: https://github.com/envato/event_sourcery/pull/229
 [#230]: https://github.com/envato/event_sourcery/pull/230
+[#232]: https://github.com/envato/event_sourcery/pull/232
 
 ## [0.23.1] - 2020-10-02
 ### Fixed


### PR DESCRIPTION
### Context

Ruby 2.3, 2.4 and 2.5 have reached their EOL. 
We removing dropping test matrixes for those ruby versions.

### Considaration

- We were unable to find an Envato application using this gem with one of the above ruby versions
- We will reach out to Envato engineering before releasing a new gem
- A new version will be released in the next  PR