### PR TITLE
Bump version 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [0.24.0] - 2021-11-18
 
 ### Added
 
@@ -252,7 +253,8 @@ moving all Postgres related code into a separate gem.
 - EventSourcery no longer depends on Virtus.
 - `Command` and `CommandHandler` have been removed.
 
-[Unreleased]: https://github.com/envato/event_sourcery/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/envato/event_sourcery/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/envato/event_sourcery/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/envato/event_sourcery/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/envato/event_sourcery/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/envato/event_sourcery/compare/v0.21.0...v0.22.0

--- a/lib/event_sourcery/version.rb
+++ b/lib/event_sourcery/version.rb
@@ -1,4 +1,4 @@
 module EventSourcery
   # Defines the version
-  VERSION = '0.23.1'.freeze
+  VERSION = '0.24.0'.freeze
 end


### PR DESCRIPTION
Bump the new version 0.24.0. The changelog is already up to date.

We will be following the "[release](https://github.com/envato/event_sourcery#release)" document for releasing the new gem version.