### PR TITLE
Fix dead documentation link in AggregateRoot

### DIFF
--- a/lib/event_sourcery/aggregate_root.rb
+++ b/lib/event_sourcery/aggregate_root.rb
@@ -5,7 +5,7 @@ module EventSourcery
   # EventSourcery::AggregateRoot provides a foundation for writing your own aggregate root classes.
   # You can use it by including it in your classes, as show in the example code.
   #
-  # Excerpt from {https://github.com/envato/event_sourcery/blob/HEAD/docs/core-concepts.md EventSourcery Core Concepts}
+  # Excerpt from {https://github.com/envato/event_sourcery/blob/HEAD/README.md#aggregates-and-command-handling EventSourcery Core Concepts}
   # on Aggregates follows:
   #
   # === Aggregates and Command Handling


### PR DESCRIPTION
The YARD comment on `EventSourcery::AggregateRoot` links to `docs/core-concepts.md`, which does not exist in the repository.

This PR repoints the link to the equivalent content in the README: `README.md#aggregates-and-command-handling`.