### PR TITLE
RuboCop: exclude the RSpec suite from Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,9 @@ AllCops:
   NewCops: disable
   SuggestExtensions: false
   TargetRubyVersion: 2.6
+
+# RSpec's DSL naturally produces long describe/context blocks, so the block
+# length metric is not meaningful for the test suite.
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,24 +25,6 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Exclude:
     - 'lib/event_sourcery/rspec/event_store_shared_examples.rb'
-    - 'spec/event_sourcery/aggregate_root_spec.rb'
-    - 'spec/event_sourcery/event_body_serializer_spec.rb'
-    - 'spec/event_sourcery/event_processing/error_handlers/constant_retry_spec.rb'
-    - 'spec/event_sourcery/event_processing/error_handlers/error_handler_spec.rb'
-    - 'spec/event_sourcery/event_processing/error_handlers/exponential_backoff_retry_spec.rb'
-    - 'spec/event_sourcery/event_processing/error_handlers/no_retry_spec.rb'
-    - 'spec/event_sourcery/event_processing/esp_process_spec.rb'
-    - 'spec/event_sourcery/event_processing/esp_runner_integration_spec.rb'
-    - 'spec/event_sourcery/event_processing/esp_runner_spec.rb'
-    - 'spec/event_sourcery/event_processing/event_stream_processor_registry_spec.rb'
-    - 'spec/event_sourcery/event_processing/event_stream_processor_spec.rb'
-    - 'spec/event_sourcery/event_spec.rb'
-    - 'spec/event_sourcery/event_store/event_builder_spec.rb'
-    - 'spec/event_sourcery/event_store/event_type_serializers/class_name_spec.rb'
-    - 'spec/event_sourcery/event_store/event_type_serializers/underscored_spec.rb'
-    - 'spec/event_sourcery/event_store/subscription_spec.rb'
-    - 'spec/event_sourcery/memory/projector_spec.rb'
-    - 'spec/event_sourcery/repository_spec.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ClassLength:


### PR DESCRIPTION
RSpec's `describe`/`context`/`it` DSL naturally produces long blocks, so the block length metric is not meaningful for the test suite.

This replaces the 18 per-file spec exclusions in the auto-generated `.rubocop_todo.yml` with a single `spec/**/*` exclusion in `.rubocop.yml`. Deliberate policy belongs in the main config rather than the generated TODO (which is meant to be whittled down as real offenses are fixed).

The shipped shared-examples file under `lib/` keeps its TODO entry, since it is gem code rather than part of the spec suite.

Net `+6/-18`. `bundle exec rake rubocop` is clean (67 files, no offenses).